### PR TITLE
feat: Added support for different Layout types

### DIFF
--- a/demo-app/src/main/kotlin/io/hyperswitch/demoapp/MainActivity.kt
+++ b/demo-app/src/main/kotlin/io/hyperswitch/demoapp/MainActivity.kt
@@ -105,6 +105,13 @@ class MainActivity : AppCompatActivity(), HyperInterface {
             surface = "#F5F8F9".toColorInt(),
         )
 
+        val layout = PaymentSheet.Layout(
+            type = PaymentSheet.LayoutType.Tabs,
+            showOneClickWalletsOnTop = true,
+            paymentMethodsArrangementForTabs = PaymentSheet.PaymentMethodsArrangement.Default
+
+        )
+
         val appearance: PaymentSheet.Appearance = PaymentSheet.Appearance(
             typography = PaymentSheet.Typography(
                 sizeScaleFactor = 1f, fontResId = R.font.montserrat
@@ -112,12 +119,13 @@ class MainActivity : AppCompatActivity(), HyperInterface {
             primaryButton = primaryButton,
             colorsLight = color1,
             colorsDark = color2,
-            theme = PaymentSheet.Theme.Light
+            theme = PaymentSheet.Theme.Light,
+            layout = layout
         )
 
         val configuration =
             PaymentSheet.Configuration.Builder("Example, Inc.")
-                //.appearance(appearance)
+                .appearance(appearance)
                 .defaultBillingDetails(billingDetails).primaryButtonLabel("Purchase ($2.00)")
                 .paymentSheetHeaderLabel("Select payment method")
                 .savedPaymentSheetHeaderLabel("Payment methods").shippingDetails(shippingDetails)

--- a/demo-app/src/main/kotlin/io/hyperswitch/demoapp/MainActivity.kt
+++ b/demo-app/src/main/kotlin/io/hyperswitch/demoapp/MainActivity.kt
@@ -105,12 +105,7 @@ class MainActivity : AppCompatActivity(), HyperInterface {
             surface = "#F5F8F9".toColorInt(),
         )
 
-        val layout = PaymentSheet.Layout(
-            type = PaymentSheet.LayoutType.Tabs,
-            showOneClickWalletsOnTop = true,
-            paymentMethodsArrangementForTabs = PaymentSheet.PaymentMethodsArrangement.Default,
-            spacedAccordionItems = false
-        )
+        val layout = PaymentSheet.Layout.Tabs()
 
         val appearance: PaymentSheet.Appearance = PaymentSheet.Appearance(
             typography = PaymentSheet.Typography(

--- a/demo-app/src/main/kotlin/io/hyperswitch/demoapp/MainActivity.kt
+++ b/demo-app/src/main/kotlin/io/hyperswitch/demoapp/MainActivity.kt
@@ -108,8 +108,8 @@ class MainActivity : AppCompatActivity(), HyperInterface {
         val layout = PaymentSheet.Layout(
             type = PaymentSheet.LayoutType.Tabs,
             showOneClickWalletsOnTop = true,
-            paymentMethodsArrangementForTabs = PaymentSheet.PaymentMethodsArrangement.Default
-
+            paymentMethodsArrangementForTabs = PaymentSheet.PaymentMethodsArrangement.Default,
+            spacedAccordionItems = false
         )
 
         val appearance: PaymentSheet.Appearance = PaymentSheet.Appearance(

--- a/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentSheet.kt
+++ b/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentSheet.kt
@@ -414,16 +414,6 @@ class PaymentSheet internal constructor(
             fun locale(locale: String) = apply { this.locale = locale }
             fun layout(layout: Layout) = apply { this.layout = layout }
 
-            fun build() = Appearance(
-                colorsLight,
-                colorsDark,
-                shapes,
-                typography,
-                primaryButton,
-                locale,
-                theme,
-                layout
-            )
         }
     }
 

--- a/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentSheet.kt
+++ b/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentSheet.kt
@@ -1010,8 +1010,7 @@ class PaymentSheet internal constructor(
 
     enum class LayoutType {
         Tabs,
-        Accordion,
-        SpacedAccordion
+        Accordion
     }
 
     enum class PaymentMethodsArrangement {
@@ -1050,7 +1049,7 @@ class PaymentSheet internal constructor(
     data class Layout(
         /**
          * The type of layout to display payment methods in.
-         * Can be Tabs, Accordion, or SpacedAccordion.
+         * Can be Tabs or Accordion.
          */
         val type: LayoutType? = null,
 

--- a/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentSheet.kt
+++ b/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentSheet.kt
@@ -375,7 +375,9 @@ class PaymentSheet internal constructor(
 
         val locale: String? = null,
 
-        val theme: Theme? = null
+        val theme: Theme? = null,
+
+        val layout: Layout? = null
     ) : Parcelable {
         val bundle: Bundle
             get() {
@@ -387,6 +389,7 @@ class PaymentSheet internal constructor(
                     putBundle("primaryButton", primaryButton?.bundle)
                     putString("locale", locale)
                     putString("theme", theme?.name)
+                    putBundle("layout", layout?.bundle)
                 }
             }
 
@@ -398,6 +401,7 @@ class PaymentSheet internal constructor(
             private var primaryButton: PrimaryButton? = null
             private var theme: Theme? = null
             private var locale: String? = null
+            private var layout: Layout? = null
 
             fun colorsLight(colors: Colors) = apply { this.colorsLight = colors }
             fun colorsDark(colors: Colors) = apply { this.colorsDark = colors }
@@ -408,6 +412,18 @@ class PaymentSheet internal constructor(
 
             fun theme(theme: Theme) = apply { this.theme = theme }
             fun locale(locale: String) = apply { this.locale = locale }
+            fun layout(layout: Layout) = apply { this.layout = layout }
+
+            fun build() = Appearance(
+                colorsLight,
+                colorsDark,
+                shapes,
+                typography,
+                primaryButton,
+                locale,
+                theme,
+                layout
+            )
         }
     }
 
@@ -990,6 +1006,108 @@ class PaymentSheet internal constructor(
         FlatMinimal,
         Minimal,
         Default,
+    }
+
+    enum class LayoutType {
+        Tabs,
+        Accordion,
+        SpacedAccordion
+    }
+
+    enum class PaymentMethodsArrangement {
+        Default,
+        Grid
+    }
+
+    enum class GroupingBehavior {
+        GroupByPaymentMethods,
+        Default
+    }
+
+    @Parcelize
+    data class SavedMethodCustomization(
+        /**
+         * How to group saved payment methods.
+         * Can be GroupByPaymentMethods or Default.
+         */
+        val groupingBehavior: GroupingBehavior? = null
+    ) : Parcelable {
+        val bundle: Bundle
+            get() {
+                return Bundle().apply {
+                    if (groupingBehavior != null) {
+                        val behaviorString = when (groupingBehavior) {
+                            GroupingBehavior.GroupByPaymentMethods -> "groupByPaymentMethods"
+                            GroupingBehavior.Default -> "default"
+                        }
+                        putString("groupingBehavior", behaviorString)
+                    }
+                }
+            }
+    }
+
+    @Parcelize
+    data class Layout(
+        /**
+         * The type of layout to display payment methods in.
+         * Can be Tabs, Accordion, or SpacedAccordion.
+         */
+        val type: LayoutType? = null,
+
+        /**
+         * Whether to show one-click wallets (like Google Pay, Apple Pay) at the top of the payment sheet.
+         */
+        val showOneClickWalletsOnTop: Boolean? = null,
+
+        /**
+         * The arrangement of payment methods in tabs layout.
+         * Can be Default or Grid.
+         */
+        val paymentMethodsArrangementForTabs: PaymentMethodsArrangement? = null,
+
+        /**
+         * Whether accordion items should be collapsed by default.
+         */
+        val defaultCollapsed: Boolean? = null,
+
+        /**
+         * Show radio buttons instead of accordion style.
+         */
+        val radios: Boolean? = null,
+
+        /**
+         * Add spacing between accordion items.
+         */
+        val spacedAccordionItems: Boolean? = null,
+
+        /**
+         * Maximum number of accordion items to show before "show more".
+         */
+        val maxAccordionItems: Int? = null,
+
+        /**
+         * Customization options for saved payment methods display.
+         */
+        val savedMethodCustomization: SavedMethodCustomization? = null
+    ) : Parcelable {
+        val bundle: Bundle
+            get() {
+                return Bundle().apply {
+                    putString("type", type?.name?.lowercase())
+                    putBoolean("showOneClickWalletsOnTop", showOneClickWalletsOnTop ?: true)
+                    putString(
+                        "paymentMethodsArrangementForTabs",
+                        paymentMethodsArrangementForTabs?.name?.lowercase()
+                    )
+                    putBoolean("defaultCollapsed", defaultCollapsed ?: false)
+                    putBoolean("radios", radios ?: false)
+                    putBoolean("spacedAccordionItems", spacedAccordionItems ?: false)
+                    if (maxAccordionItems != null) {
+                        putInt("maxAccordionItems", maxAccordionItems)
+                    }
+                    putBundle("savedMethodCustomization", savedMethodCustomization?.bundle)
+                }
+            }
     }
 
     /**

--- a/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentSheet.kt
+++ b/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentSheet.kt
@@ -1008,11 +1008,6 @@ class PaymentSheet internal constructor(
         Default,
     }
 
-    enum class LayoutType {
-        Tabs,
-        Accordion
-    }
-
     enum class PaymentMethodsArrangement {
         Default,
         Grid
@@ -1045,68 +1040,116 @@ class PaymentSheet internal constructor(
             }
     }
 
-    @Parcelize
-    data class Layout(
-        /**
-         * The type of layout to display payment methods in.
-         * Can be Tabs or Accordion.
-         */
-        val type: LayoutType? = null,
+    sealed class Layout : Parcelable {
+        abstract val bundle: Bundle
 
-        /**
-         * Whether to show one-click wallets (like Google Pay, Apple Pay) at the top of the payment sheet.
-         */
-        val showOneClickWalletsOnTop: Boolean? = null,
-
-        /**
-         * The arrangement of payment methods in tabs layout.
-         * Can be Default or Grid.
-         */
-        val paymentMethodsArrangementForTabs: PaymentMethodsArrangement? = null,
-
-        /**
-         * Whether accordion items should be collapsed by default.
-         */
-        val defaultCollapsed: Boolean? = null,
-
-        /**
-         * Show radio buttons instead of accordion style.
-         */
-        val radios: Boolean? = null,
-
-        /**
-         * Add spacing between accordion items.
-         */
-        val spacedAccordionItems: Boolean? = null,
-
-        /**
-         * Maximum number of accordion items to show before "show more".
-         */
-        val maxAccordionItems: Int? = null,
-
-        /**
-         * Customization options for saved payment methods display.
-         */
-        val savedMethodCustomization: SavedMethodCustomization? = null
-    ) : Parcelable {
-        val bundle: Bundle
-            get() {
-                return Bundle().apply {
-                    putString("type", type?.name?.lowercase())
-                    putBoolean("showOneClickWalletsOnTop", showOneClickWalletsOnTop ?: true)
-                    putString(
-                        "paymentMethodsArrangementForTabs",
-                        paymentMethodsArrangementForTabs?.name?.lowercase()
-                    )
-                    putBoolean("defaultCollapsed", defaultCollapsed ?: false)
-                    putBoolean("radios", radios ?: false)
-                    putBoolean("spacedAccordionItems", spacedAccordionItems ?: false)
-                    if (maxAccordionItems != null) {
-                        putInt("maxAccordionItems", maxAccordionItems)
+        @Parcelize
+        data class Tabs(
+            val showOneClickWalletsOnTop: Boolean = true,
+            val paymentMethodsArrangement: PaymentMethodsArrangement = PaymentMethodsArrangement.Default,
+            val savedMethodCustomization: SavedMethodCustomization? = null
+        ) : Layout() {
+            override val bundle: Bundle
+                get() {
+                    return Bundle().apply {
+                        putString("type", "tabs")
+                        putBoolean("showOneClickWalletsOnTop", showOneClickWalletsOnTop)
+                        putString(
+                            "paymentMethodsArrangementForTabs",
+                            paymentMethodsArrangement.name.lowercase()
+                        )
+                        putBoolean("defaultCollapsed", false)
+                        putBoolean("radios", false)
+                        putBoolean("spacedAccordionItems", false)
+                        putBundle("savedMethodCustomization", savedMethodCustomization?.bundle)
                     }
-                    putBundle("savedMethodCustomization", savedMethodCustomization?.bundle)
                 }
+
+            class Builder {
+                private var showOneClickWalletsOnTop: Boolean = true
+                private var paymentMethodsArrangement: PaymentMethodsArrangement =
+                    PaymentMethodsArrangement.Default
+                private var savedMethodCustomization: SavedMethodCustomization? = null
+
+                fun setShowOneClickWalletsOnTop(value: Boolean) =
+                    apply { this.showOneClickWalletsOnTop = value }
+
+                fun setPaymentMethodsArrangement(value: PaymentMethodsArrangement) =
+                    apply { this.paymentMethodsArrangement = value }
+
+                fun setSavedMethodCustomization(value: SavedMethodCustomization) =
+                    apply { this.savedMethodCustomization = value }
+
+                fun build() = Tabs(
+                    showOneClickWalletsOnTop,
+                    paymentMethodsArrangement,
+                    savedMethodCustomization
+                )
             }
+        }
+
+        @Parcelize
+        data class Accordion(
+            val showOneClickWalletsOnTop: Boolean = true,
+            val defaultCollapsed: Boolean = false,
+            val radios: Boolean = false,
+            val spacedAccordionItems: Boolean = false,
+            val maxAccordionItems: Int = 4,
+            val savedMethodCustomization: SavedMethodCustomization? = null
+        ) : Layout() {
+            override val bundle: Bundle
+                get() {
+                    return Bundle().apply {
+                        putString("type", "accordion")
+                        putBoolean("showOneClickWalletsOnTop", showOneClickWalletsOnTop)
+                        putString(
+                            "paymentMethodsArrangementForTabs",
+                            PaymentMethodsArrangement.Default.name.lowercase()
+                        )
+                        putBoolean("defaultCollapsed", defaultCollapsed)
+                        putBoolean("radios", radios)
+                        putBoolean("spacedAccordionItems", spacedAccordionItems)
+                        putInt("maxAccordionItems", maxAccordionItems)
+                        putBundle("savedMethodCustomization", savedMethodCustomization?.bundle)
+                    }
+                }
+
+            class Builder {
+                private var showOneClickWalletsOnTop: Boolean = true
+                private var defaultCollapsed: Boolean = false
+                private var radios: Boolean = false
+                private var spacedAccordionItems: Boolean = false
+                private var maxAccordionItems: Int = 4
+                private var savedMethodCustomization: SavedMethodCustomization? = null
+
+                fun setShowOneClickWalletsOnTop(value: Boolean) =
+                    apply { this.showOneClickWalletsOnTop = value }
+
+                fun setDefaultCollapsed(value: Boolean) =
+                    apply { this.defaultCollapsed = value }
+
+                fun setRadios(value: Boolean) =
+                    apply { this.radios = value }
+
+                fun setSpacedAccordionItems(value: Boolean) =
+                    apply { this.spacedAccordionItems = value }
+
+                fun setMaxAccordionItems(value: Int) =
+                    apply { this.maxAccordionItems = value }
+
+                fun setSavedMethodCustomization(value: SavedMethodCustomization) =
+                    apply { this.savedMethodCustomization = value }
+
+                fun build() = Accordion(
+                    showOneClickWalletsOnTop,
+                    defaultCollapsed,
+                    radios,
+                    spacedAccordionItems,
+                    maxAccordionItems,
+                    savedMethodCustomization
+                )
+            }
+        }
     }
 
     /**

--- a/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentSheet.kt
+++ b/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentSheet.kt
@@ -1003,16 +1003,22 @@ class PaymentSheet internal constructor(
         Grid
     }
 
-    enum class GroupingBehavior {
-        GroupByPaymentMethods,
-        Default
+    @Parcelize
+    data class GroupingBehavior(
+        val displayInSeparateScreen: Boolean = true,
+        val groupByPaymentMethods: Boolean = false
+    ) : Parcelable {
+        val bundle: Bundle
+            get() = Bundle().apply {
+                putBoolean("displayInSeparateScreen", displayInSeparateScreen)
+                putBoolean("groupByPaymentMethods", groupByPaymentMethods)
+            }
     }
 
     @Parcelize
     data class SavedMethodCustomization(
         /**
-         * How to group saved payment methods.
-         * Can be GroupByPaymentMethods or Default.
+         * How to group and display saved payment methods.
          */
         val groupingBehavior: GroupingBehavior? = null
     ) : Parcelable {
@@ -1020,11 +1026,7 @@ class PaymentSheet internal constructor(
             get() {
                 return Bundle().apply {
                     if (groupingBehavior != null) {
-                        val behaviorString = when (groupingBehavior) {
-                            GroupingBehavior.GroupByPaymentMethods -> "groupByPaymentMethods"
-                            GroupingBehavior.Default -> "default"
-                        }
-                        putString("groupingBehavior", behaviorString)
+                        putBundle("groupingBehavior", groupingBehavior.bundle)
                     }
                 }
             }


### PR DESCRIPTION
## Description

Adds native Android API support for structured layout configuration in the Payment Sheet. Merchants can now customize the payment UI layout type, arrangement, and saved method grouping behavior through a typed Kotlin API.

---

## What's New

- **`PaymentSheet.Layout`** — Sealed class with `Tabs` and `Accordion` variants
- **`PaymentMethodsArrangement`** — Enum to switch between `Default` (horizontal scroll) and `Grid` layout
- **`GroupingBehavior`** — Controls whether saved methods are grouped by payment type or shown inline
- **`SavedMethodCustomization`** — Wraps grouping behavior config for saved payment methods
- **Accordion-specific options** — `spacedAccordionItems`, `maxAccordionItems`, `radios`

---

## Key Changes

- **`PaymentSheet.kt`**
  - Added `Layout` sealed class
  - Added `PaymentMethodsArrangement` enum
  - Added `GroupingBehavior`
  - Added `SavedMethodCustomization` with builder support
  - Wired layout config into `Appearance.Configuration`

- **`MainActivity.kt`**
  - Updated demo to use `PaymentSheet.Layout.Tabs()` for validation

---

## Test Cases

Screen recordings are attached for all scenarios below.

### Tabs Layout

| #  | Config | Description |
|----|--------|-------------|
| 1  | `Tabs + groupByPaymentMethods: true` | Saved methods grouped by payment type |
| 5  | `Tabs()` | Default tabs, no customization |
| 10 | `Tabs + PaymentMethodsArrangement.Grid` | Payment methods in grid arrangement |
| 12 | `Tabs + groupByPaymentMethods: false` | Saved methods shown inline (not grouped) |

### Accordion Layout

| #  | Config | Description |
|----|--------|-------------|
| 2  | `Accordion + spacedAccordionItems: true + groupByPaymentMethods: true` | Spaced accordion, saved methods grouped |
| 4  | `Accordion()` | Default accordion, no customization |
| 6  | `Accordion + spacedAccordionItems: true` | Spaced accordion, no saved method customization |
| 7  | `Accordion + spacedAccordionItems: true + maxAccordionItems: 5` | Capped at 5 visible items |
| 8  | `Accordion + spacedAccordionItems: true + maxAccordionItems: 5 + radios: true` | Radio buttons, capped at 5 |
| 9  | `Accordion + radios: true + spacedAccordionItems: true + maxAccordionItems: 3` | Radio buttons, capped at 3 |
| 11 | `Accordion + spacedAccordionItems: true + groupByPaymentMethods: false` | Spaced accordion, saved methods inline |


### Test Cases 

## Description

Adds native Android API support for structured layout configuration in the Payment Sheet. Merchants can now customize the payment UI layout type, arrangement, and saved method grouping behavior through a typed Kotlin API.

---

## What's New

- **`PaymentSheet.Layout`** — Sealed class with `Tabs` and `Accordion` variants
- **`PaymentMethodsArrangement`** — Enum to switch between `Default` (horizontal scroll) and `Grid` layout
- **`GroupingBehavior`** — Controls whether saved methods are grouped by payment type or shown inline
- **`SavedMethodCustomization`** — Wraps grouping behavior config for saved payment methods
- **Accordion-specific options** — `spacedAccordionItems`, `maxAccordionItems`, `radios`

---

## Key Changes

- **`PaymentSheet.kt`**
  - Added `Layout` sealed class
  - Added `PaymentMethodsArrangement` enum
  - Added `GroupingBehavior`
  - Added `SavedMethodCustomization` with builder support
  - Wired layout config into `Appearance.Configuration`

- **`MainActivity.kt`**
  - Updated demo to use `PaymentSheet.Layout.Tabs()` for validation

---

## Test Cases

Screen recordings are attached for all scenarios below.

| # | Layout | Scenario |
|---|--------|----------|
| 1 | Tabs | Saved methods grouped by payment methods |
| 2 | Accordion | Saved methods grouped by payment methods |
| 3 | Accordion | Same as above with `spacedAccordionItems` |
| 4 | Accordion | Default accordion |
| 5 | Tabs | Default tabs |
| 6 | Accordion | Spaced accordion items |
| 7 | Accordion | Spaced accordion with `maxAccordionItems = 5` |
| 8 | Accordion | Radio buttons with `maxAccordionItems = 5` |
| 9 | Accordion | Radio buttons with `maxAccordionItems = 3` |
| 10 | Tabs | Grid payment methods arrangement |
| 11 | Accordion | Saved methods shown inline |
| 12 | Tabs | Saved methods shown inline |

---

## Layout Test Suite for Android

### 1. Tabs — Saved methods grouped by payment methods

```kotlin
val layout = PaymentSheet.Layout.Tabs(
    savedMethodCustomization = PaymentSheet.SavedMethodCustomization(
        groupingBehavior = PaymentSheet.GroupingBehavior(
            displayInSeparateScreen = false,
            groupByPaymentMethods = true
        )
    )
)
```

### 2. Accordion — Saved methods grouped by payment methods

```kotlin
val layout = PaymentSheet.Layout.Accordion(
    spacedAccordionItems = true,
    savedMethodCustomization = PaymentSheet.SavedMethodCustomization(
        groupingBehavior = PaymentSheet.GroupingBehavior(
            displayInSeparateScreen = false,
            groupByPaymentMethods = true
        )
    )
)
```

### 3. Accordion — Same as above with `spacedAccordionItems`

```kotlin
val layout = PaymentSheet.Layout.Accordion(
    spacedAccordionItems = true,
    savedMethodCustomization = PaymentSheet.SavedMethodCustomization(
        groupingBehavior = PaymentSheet.GroupingBehavior(
            displayInSeparateScreen = false,
            groupByPaymentMethods = true
        )
    )
)
```

### 4. Accordion — Default

```kotlin
val layout = PaymentSheet.Layout.Accordion()
```

### 5. Tabs — Default

```kotlin
val layout = PaymentSheet.Layout.Tabs()
```

### 6. Accordion — Spaced items

```kotlin
val layout = PaymentSheet.Layout.Accordion(
    spacedAccordionItems = true
)
```

### 7. Accordion — Spaced items with max 5 visible items

```kotlin
val layout = PaymentSheet.Layout.Accordion(
    spacedAccordionItems = true,
    maxAccordionItems = 5
)
```

### 8. Accordion — Radio buttons with max 5 visible items

```kotlin
val layout = PaymentSheet.Layout.Accordion(
    spacedAccordionItems = true,
    maxAccordionItems = 5,
    radios = true
)
```

### 9. Accordion — Radio buttons with max 3 visible items

```kotlin
val layout = PaymentSheet.Layout.Accordion(
    radios = true,
    spacedAccordionItems = true,
    maxAccordionItems = 3
)
```

### 10. Tabs — Grid payment methods arrangement

```kotlin
val layout = PaymentSheet.Layout.Tabs(
    paymentMethodsArrangement = PaymentSheet.PaymentMethodsArrangement.Grid
)
```

### 11. Accordion — Saved methods shown inline

```kotlin
val layout = PaymentSheet.Layout.Accordion(
    spacedAccordionItems = true,
    savedMethodCustomization = PaymentSheet.SavedMethodCustomization(
        groupingBehavior = PaymentSheet.GroupingBehavior(
            displayInSeparateScreen = false,
            groupByPaymentMethods = false
        )
    )
)
```

### 12. Tabs — Saved methods shown inline

```kotlin
val layout = PaymentSheet.Layout.Tabs(
    savedMethodCustomization = PaymentSheet.SavedMethodCustomization(
        groupingBehavior = PaymentSheet.GroupingBehavior(
            displayInSeparateScreen = false,
            groupByPaymentMethods = false
        )
    )
)
```

### Screenrecording

https://github.com/user-attachments/assets/987ce28e-3640-4054-a9bf-20db2295aa76


https://github.com/user-attachments/assets/b144f6a5-f2f0-4f31-9d31-dd2da64ba22c


https://github.com/user-attachments/assets/23b41afc-f57b-4cf5-816e-5f9548d11ad7


https://github.com/user-attachments/assets/626a97ac-2353-4334-8ebd-3ff32688b90e


https://github.com/user-attachments/assets/2615f1c4-7514-4945-a6ec-3246a01a8f4a


https://github.com/user-attachments/assets/971d483b-85e1-49ef-9e88-a706938f2aea


https://github.com/user-attachments/assets/0e965907-e2ca-40c4-8918-0f6e99c65416


https://github.com/user-attachments/assets/2f110437-6617-4460-a23d-020016b25cc6


https://github.com/user-attachments/assets/29ce38b6-ca7c-4f1f-a369-9a77639afb22


https://github.com/user-attachments/assets/83ebc831-4989-489e-80b4-bc509068e244


https://github.com/user-attachments/assets/b2b3455e-e3a0-46b3-ac28-12453d418749


https://github.com/user-attachments/assets/3129715f-a5f1-4557-8e3a-9c5b7312d0ea

