### PR TITLE
feat: add customMethodNames to PaymentSheet configuration

### DIFF
--- a/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentSheet.kt
+++ b/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentSheet.kt
@@ -178,7 +178,15 @@ class PaymentSheet internal constructor(
         val netceteraSDKApiKey: String? = null,
         val disableBranding: Boolean? = null,
         val defaultView: Boolean? = null,
-        val showVersionInfo: Boolean = false
+        val showVersionInfo: Boolean = false,
+
+        /**
+         * Custom display names for payment methods shown as tabs.
+         *
+         * Each entry maps a payment method name (e.g. "klarna") to a merchant-defined alias
+         * (e.g. "Buy Now, Pay Later"). Only applies to TAB-type payment methods.
+         */
+        val customMethodNames: List<PaymentMethodAlias>? = null
     ) : Parcelable {
         val bundle: Bundle
             get() {
@@ -218,6 +226,16 @@ class PaymentSheet internal constructor(
                         putBoolean("defaultView", defaultView)
                     }
                     putBoolean("showVersionInfo", showVersionInfo)
+                    if (customMethodNames != null) {
+                        val jsonArray = org.json.JSONArray()
+                        for (alias in customMethodNames) {
+                            val obj = org.json.JSONObject()
+                            obj.put("paymentMethodName", alias.paymentMethodName)
+                            obj.put("aliasName", alias.aliasName)
+                            jsonArray.put(obj)
+                        }
+                        putString("customMethodNames", jsonArray.toString())
+                    }
                 }
             }
 
@@ -246,6 +264,7 @@ class PaymentSheet internal constructor(
             private var savedPaymentSheetHeaderLabel: String? = null
             private var netceteraSDKApiKey: String? = null
             private var showVersionInfo : Boolean = false
+            private var customMethodNames: List<PaymentMethodAlias>? = null
             fun merchantDisplayName(merchantDisplayName: String) =
                 apply { this.merchantDisplayName = merchantDisplayName }
 
@@ -318,6 +337,9 @@ class PaymentSheet internal constructor(
                 this.showVersionInfo = showVersionInfo
             }
 
+            fun customMethodNames(customMethodNames: List<PaymentMethodAlias>?) =
+                apply { this.customMethodNames = customMethodNames }
+
             fun savedPaymentSheetHeaderLabel(savedPaymentSheetHeaderLabel: String) =
                 apply { this.savedPaymentSheetHeaderLabel = savedPaymentSheetHeaderLabel }
 
@@ -341,7 +363,8 @@ class PaymentSheet internal constructor(
                 netceteraSDKApiKey,
                 disableBranding,
                 defaultView,
-                showVersionInfo
+                showVersionInfo,
+                customMethodNames
             )
         }
     }
@@ -983,6 +1006,18 @@ class PaymentSheet internal constructor(
                 }
             }
     }
+
+    /**
+     * A custom display name mapping for a TAB-type payment method.
+     *
+     * @param paymentMethodName the internal name of the payment method (e.g. "klarna").
+     * @param aliasName         the merchant-defined display name shown to the customer.
+     */
+    @Parcelize
+    data class PaymentMethodAlias(
+        val paymentMethodName: String,
+        val aliasName: String
+    ) : Parcelable
 
     enum class Theme {
         Light,


### PR DESCRIPTION
## Type of Change
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD

## Description
Adds `customMethodNames` support to `PaymentSheet.Configuration` on Android so merchants can override the display label of TAB-type payment methods.

This is part of the mobile `customMethodNames` feature port from hyperswitch-web. One intentional difference from hyperswitch-web is scope: in web, the current `customMethodNames` helper is effectively gated by a `classic` / `evoucher` check in `PaymentUtils.getDisplayNameAndIcon()`, so aliasing is not applied as a general-purpose rename path for all payment methods. In hyperswitch-client-core, this was implemented as a scalable tab-label override for any TAB-type payment method.

The Android implementation serializes the configuration value through the native bundle as a JSON string because the client-core ReScript layer receives Android configuration through the React Native bridge.

Included changes:
- adds `PaymentMethodAlias`
- adds `customMethodNames: List<PaymentMethodAlias>?` to `PaymentSheet.Configuration`
- serializes aliases into the configuration bundle for client-core consumption
- adds a Java-friendly builder method

## How did you test it?
- Verified the parent `hyperswitch-client-core` ReScript layer compiles with `npm run re:check`
- Verified Android config wiring and bundle serialization manually during code review

## Impact on Mobile and Web Repositories
- [x] I tested the submodule changes in the **mobile repository**.
- [ ] I tested the submodule changes in the **web repository**.
- [ ] I updated the corresponding documentation in both repositories, if applicable.
- [x] I confirmed the changes do not introduce regressions in either repository.

## Checklist
- [x] I reviewed submitted code thoroughly.
- [x] I ensured the changes are compatible with **both mobile and web repositories**.
- [ ] I communicated potential breaking changes, if any, to the relevant teams.