### PR TITLE
feat: add hideCardNicknameField configuration option

### DIFF
--- a/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentSheet.kt
+++ b/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentSheet.kt
@@ -170,6 +170,7 @@ class PaymentSheet internal constructor(
         val savedPaymentSheetHeaderLabel: String? = null,
         val displayDefaultSavedPaymentIcon: Boolean? = null,
         val displaySavedPaymentMethodsCheckbox: Boolean? = null,
+        val hideCardNicknameField: Boolean? = null,
         val displaySavedPaymentMethods: Boolean? = null,
         val placeHolder: PlaceHolder? = null,
         /**
@@ -206,6 +207,9 @@ class PaymentSheet internal constructor(
                             displaySavedPaymentMethodsCheckbox
                         )
                     }
+                    if (hideCardNicknameField != null) {
+                        putBoolean("hideCardNicknameField", hideCardNicknameField)
+                    }
                     if (displaySavedPaymentMethods != null) {
                         putBoolean("displaySavedPaymentMethods", displaySavedPaymentMethods)
                     }
@@ -236,6 +240,7 @@ class PaymentSheet internal constructor(
             private var allowsPaymentMethodsRequiringShippingAddress: Boolean = false
             private var appearance: Appearance? = null
             private var displaySavedPaymentMethodsCheckbox: Boolean = true
+            private var hideCardNicknameField: Boolean = false
             private var displaySavedPaymentMethods: Boolean = true
             private var placeHolder: PlaceHolder? = null
             private var primaryButtonLabel: String? = null
@@ -289,6 +294,9 @@ class PaymentSheet internal constructor(
                     this.displaySavedPaymentMethodsCheckbox = displaySavedPaymentMethodsCheckbox
                 }
 
+            fun hideCardNicknameField(hideCardNicknameField: Boolean) =
+                apply { this.hideCardNicknameField = hideCardNicknameField }
+
             fun displaySavedPaymentMethods(displaySavedPaymentMethods: Boolean) =
                 apply { this.displaySavedPaymentMethods = displaySavedPaymentMethods }
 
@@ -336,6 +344,7 @@ class PaymentSheet internal constructor(
                 savedPaymentSheetHeaderLabel,
                 displayDefaultSavedPaymentIcon,
                 displaySavedPaymentMethodsCheckbox,
+                hideCardNicknameField,
                 displaySavedPaymentMethods,
                 placeHolder,
                 netceteraSDKApiKey,


### PR DESCRIPTION
## Summary
- Adds `hideCardNicknameField` boolean configuration option to `PaymentSheet.Configuration`
- When set to `true`, the card nickname input field will be hidden during card payment flow
- Default value is `false` (nickname field is shown)
## Changes
- Added `hideCardNicknameField` property to `Configuration` data class
- Added bundle serialization for passing to React Native layer
- Added builder method `hideCardNicknameField(Boolean)` for Java/Kotlin configuration
## Usage
```kotlin
val configuration = PaymentSheet.Configuration.Builder("Merchant Name")
    .displaySavedPaymentMethodsCheckbox(true)
    .hideCardNicknameField(true) // Hides the nickname field
    .build()