### PR TITLE
feat: add savedPaymentMethodsCheckboxCheckedByDefault config prop

### DIFF
--- a/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentSheet.kt
+++ b/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentSheet.kt
@@ -170,6 +170,7 @@ class PaymentSheet internal constructor(
         val savedPaymentSheetHeaderLabel: String? = null,
         val displayDefaultSavedPaymentIcon: Boolean? = null,
         val displaySavedPaymentMethodsCheckbox: Boolean? = null,
+        val savedPaymentMethodsCheckboxCheckedByDefault: Boolean? = null,
         val displaySavedPaymentMethods: Boolean? = null,
         val placeHolder: PlaceHolder? = null,
         /**
@@ -206,6 +207,12 @@ class PaymentSheet internal constructor(
                             displaySavedPaymentMethodsCheckbox
                         )
                     }
+                    if (savedPaymentMethodsCheckboxCheckedByDefault != null) {
+                        putBoolean(
+                            "savedPaymentMethodsCheckboxCheckedByDefault",
+                            savedPaymentMethodsCheckboxCheckedByDefault
+                        )
+                    }
                     if (displaySavedPaymentMethods != null) {
                         putBoolean("displaySavedPaymentMethods", displaySavedPaymentMethods)
                     }
@@ -236,6 +243,7 @@ class PaymentSheet internal constructor(
             private var allowsPaymentMethodsRequiringShippingAddress: Boolean = false
             private var appearance: Appearance? = null
             private var displaySavedPaymentMethodsCheckbox: Boolean = true
+            private var savedPaymentMethodsCheckboxCheckedByDefault: Boolean = false
             private var displaySavedPaymentMethods: Boolean = true
             private var placeHolder: PlaceHolder? = null
             private var primaryButtonLabel: String? = null
@@ -289,6 +297,11 @@ class PaymentSheet internal constructor(
                     this.displaySavedPaymentMethodsCheckbox = displaySavedPaymentMethodsCheckbox
                 }
 
+            fun savedPaymentMethodsCheckboxCheckedByDefault(savedPaymentMethodsCheckboxCheckedByDefault: Boolean) =
+                apply {
+                    this.savedPaymentMethodsCheckboxCheckedByDefault = savedPaymentMethodsCheckboxCheckedByDefault
+                }
+
             fun displaySavedPaymentMethods(displaySavedPaymentMethods: Boolean) =
                 apply { this.displaySavedPaymentMethods = displaySavedPaymentMethods }
 
@@ -336,6 +349,7 @@ class PaymentSheet internal constructor(
                 savedPaymentSheetHeaderLabel,
                 displayDefaultSavedPaymentIcon,
                 displaySavedPaymentMethodsCheckbox,
+                savedPaymentMethodsCheckboxCheckedByDefault,
                 displaySavedPaymentMethods,
                 placeHolder,
                 netceteraSDKApiKey,


### PR DESCRIPTION
## Summary
- Add `savedPaymentMethodsCheckboxCheckedByDefault` prop to `PaymentSheet.Configuration`
- When `true`, the save card details checkbox is pre-checked by default
- Defaults to `false`
## Changes
- Added field to `Configuration` data class (`Boolean? = null`)
- Added serialization in `bundle` getter
- Added Builder field (default `false`), setter method, and `build()` param