### PR TITLE
feat: add sdkAuthorization update method in PaymentSession and handleauthorization in Elements

### DIFF
--- a/app/src/main/kotlin/io/hyperswitch/sdk/Elements.kt
+++ b/app/src/main/kotlin/io/hyperswitch/sdk/Elements.kt
@@ -126,6 +126,9 @@ class Elements internal constructor(
                 .forEach { (e, r) -> put(e, r.exceptionOrNull() ?: IllegalStateException("Complete failed")) }
         }
 
+        if(sdkAuthorization.isNotEmpty()) {
+            paymentSession.updateSdkAuthorization(sdkAuthorization)
+        }
         return when {
             failed.isEmpty() -> ElementsUpdateResult.Success
             succeeded.isEmpty() -> ElementsUpdateResult.TotalFailure(

--- a/app/src/main/kotlin/io/hyperswitch/sdk/PaymentSession.kt
+++ b/app/src/main/kotlin/io/hyperswitch/sdk/PaymentSession.kt
@@ -23,8 +23,9 @@ import io.hyperswitch.react.HyperEventEmitter
 class PaymentSession internal constructor(
     private val paymentSessionLauncher: PaymentSessionLauncher,
     private val publishableKey: String? = null,
-    private val sessionConfig: PaymentSessionConfiguration? = null
+    sessionConfig: PaymentSessionConfiguration? = null
 ) {
+    private var sessionConfig = sessionConfig
     constructor(activity: Activity, publishableKey: String) : this(
         DefaultPaymentSessionLauncher(activity, publishableKey, null, null, null),
         publishableKey = publishableKey,
@@ -141,6 +142,11 @@ class PaymentSession internal constructor(
         resultCallback: (PaymentResult) -> Unit
     ) {
         paymentSessionLauncher.presentPaymentSheet(configuration, subscribe, resultCallback)
+    }
+
+
+    fun updateSdkAuthorization(sdkAuthorization: String){
+        this.sessionConfig = PaymentSessionConfiguration(sdkAuthorization)
     }
 
     fun presentPaymentSheet(


### PR DESCRIPTION
This pull request introduces an update mechanism for the SDK authorization within the payment session flow, ensuring that the latest authorization is used when updating elements. The most important changes are as follows:

**SDK Authorization Update Mechanism:**

* Added a check in `Elements.kt` to update the `PaymentSession` with a new SDK authorization when available, ensuring the session always has the latest credentials.
* Introduced an `updateSdkAuthorization` method in the `PaymentSession` class to allow updating the session configuration with a new SDK authorization string.

**Session Configuration Handling:**

* Changed the `sessionConfig` property in `PaymentSession` from a constructor parameter to a mutable property, enabling it to be updated after initialization.