### PR TITLE
fix: make profileId optional throughout PaymentSession surface

### DIFF
--- a/app/src/main/kotlin/io/hyperswitch/paymentsession/DefaultPaymentSessionLauncher.kt
+++ b/app/src/main/kotlin/io/hyperswitch/paymentsession/DefaultPaymentSessionLauncher.kt
@@ -18,13 +18,15 @@ class DefaultPaymentSessionLauncher(
     customBackendUrl: String?,
     customLogUrl: String?,
     customParams: Bundle?,
+    profileId: String? = null,
     private var paymentSessionReactLauncher: SDKInterface = PaymentSessionReactLauncher(activity)
 ) : BasePaymentSessionLauncher(
     activity,
     publishableKey,
     customBackendUrl,
     customLogUrl,
-    customParams
+    customParams,
+    profileId,
 ) {
 
     init {

--- a/app/src/main/kotlin/io/hyperswitch/sdk/HyperswitchInstance.kt
+++ b/app/src/main/kotlin/io/hyperswitch/sdk/HyperswitchInstance.kt
@@ -22,7 +22,7 @@ class HyperswitchInstance internal constructor(
         } else {
             initDeferred.await()
         }
-        val ps = PaymentSession(activity, hsConfig?.publishableKey, sessionConfig = config)
+        val ps = PaymentSession(activity, hsConfig?.publishableKey, sessionConfig = config, profileId = hsConfig?.profileId)
         ps.initPaymentSession(config.sdkAuthorization)
         return ps
     }
@@ -35,7 +35,7 @@ class HyperswitchInstance internal constructor(
             } else {
                 initDeferred.await()
             }
-            val ps = PaymentSession(activity, hsConfig?.publishableKey, sessionConfig = config)
+            val ps = PaymentSession(activity, hsConfig?.publishableKey, sessionConfig = config, profileId = hsConfig?.profileId)
             ps.initPaymentSession(config.sdkAuthorization)
             withContext(Dispatchers.Main) { onResult(ps) }
         }

--- a/app/src/main/kotlin/io/hyperswitch/sdk/PaymentSession.kt
+++ b/app/src/main/kotlin/io/hyperswitch/sdk/PaymentSession.kt
@@ -26,16 +26,16 @@ class PaymentSession internal constructor(
     sessionConfig: PaymentSessionConfiguration? = null
 ) {
     private var sessionConfig = sessionConfig
-    constructor(activity: Activity, publishableKey: String) : this(
-        DefaultPaymentSessionLauncher(activity, publishableKey, null, null, null),
+    constructor(activity: Activity, publishableKey: String, profileId: String? = null) : this(
+        DefaultPaymentSessionLauncher(activity, publishableKey, null, null, null, profileId),
         publishableKey = publishableKey,
         sessionConfig = null
     )
 
     constructor(
-        activity: Activity, publishableKey: String, customBackendUrl: String
+        activity: Activity, publishableKey: String, customBackendUrl: String, profileId: String? = null
     ) : this(
-        DefaultPaymentSessionLauncher(activity, publishableKey, customBackendUrl, null, null),
+        DefaultPaymentSessionLauncher(activity, publishableKey, customBackendUrl, null, null, profileId),
         publishableKey = publishableKey,
         sessionConfig = null
     )
@@ -45,13 +45,14 @@ class PaymentSession internal constructor(
             config?.publishableKey,
             config?.customConfig?.overrideCustomBackendEndpoint,
             config?.customConfig?.overrideCustomLoggingEndpoint,
-            null),
+            null,
+            config?.profileId),
         publishableKey = config?.publishableKey,
         sessionConfig = sessionConfig
     )
 
-    constructor(activity: Activity, publishableKey: String?, sessionConfig: PaymentSessionConfiguration) : this(
-        DefaultPaymentSessionLauncher(activity, publishableKey, null, null, null),
+    constructor(activity: Activity, publishableKey: String?, sessionConfig: PaymentSessionConfiguration, profileId: String? = null) : this(
+        DefaultPaymentSessionLauncher(activity, publishableKey, null, null, null, profileId),
         publishableKey = publishableKey,
         sessionConfig = sessionConfig
     )
@@ -61,17 +62,18 @@ class PaymentSession internal constructor(
         activity: Activity,
         publishableKey: String,
         customBackendUrl: String,
-        customLogUrl: String
+        customLogUrl: String,
+        profileId: String? = null,
     ) : this(
         DefaultPaymentSessionLauncher(
-            activity, publishableKey, customBackendUrl, customLogUrl, null
+            activity, publishableKey, customBackendUrl, customLogUrl, null, profileId
         ),
         publishableKey = publishableKey,
         sessionConfig = null
     )
 
-    constructor(activity: Activity, publishableKey: String, customParams: Bundle) : this(
-        DefaultPaymentSessionLauncher(activity, publishableKey, null, null, customParams),
+    constructor(activity: Activity, publishableKey: String, customParams: Bundle, profileId: String? = null) : this(
+        DefaultPaymentSessionLauncher(activity, publishableKey, null, null, customParams, profileId),
         publishableKey = publishableKey,
         sessionConfig = null
     )
@@ -81,10 +83,11 @@ class PaymentSession internal constructor(
         publishableKey: String,
         customBackendUrl: String,
         customLogUrl: String,
-        customParams: Bundle
+        customParams: Bundle,
+        profileId: String? = null,
     ) : this(
         DefaultPaymentSessionLauncher(
-            activity, publishableKey, customBackendUrl, customLogUrl, customParams
+            activity, publishableKey, customBackendUrl, customLogUrl, customParams, profileId
         ),
         publishableKey = publishableKey,
         sessionConfig = null
@@ -99,14 +102,16 @@ class PaymentSession internal constructor(
         private var customBackendUrl: String? = null
         private var customLogUrl: String? = null
         private var customParams: Bundle? = null
+        private var profileId: String? = null
 
         fun customBackendUrl(url: String) = apply { this.customBackendUrl = url }
         fun customLogUrl(url: String) = apply { this.customLogUrl = url }
         fun customParams(params: Bundle) = apply { this.customParams = params }
+        fun profileId(profileId: String?) = apply { this.profileId = profileId }
 
         fun build(): PaymentSession {
             val launcher = DefaultPaymentSessionLauncher(
-                activity, publishableKey, customBackendUrl, customLogUrl, customParams
+                activity, publishableKey, customBackendUrl, customLogUrl, customParams, profileId
             )
             return PaymentSession(launcher, publishableKey, null)
         }

--- a/app/src/main/kotlin/io/hyperswitch/view/PaymentWidgetView.kt
+++ b/app/src/main/kotlin/io/hyperswitch/view/PaymentWidgetView.kt
@@ -107,11 +107,11 @@ class PaymentWidgetView : FrameLayout {
     private var widgetType: String? = null
 
     fun initWidget(publishableKey: String) {
-        initWidget(publishableKey, this.profileId ?: "")
+        initWidget(publishableKey, this.profileId)
     }
 
     fun initWidget(
-        publishableKey: String, profileId: String
+        publishableKey: String, profileId: String?
     ) {
         initWidget(
             mContext.applicationContext as Application,
@@ -125,7 +125,7 @@ class PaymentWidgetView : FrameLayout {
         application: Application,
         type: String,
         publishableKey: String,
-        profileId: String,
+        profileId: String?,
     ) {
         this.widgetType = type
         this.publishableKey = publishableKey

--- a/demo-app/src/main/kotlin/io/hyperswitch/demoapp/MainActivity.kt
+++ b/demo-app/src/main/kotlin/io/hyperswitch/demoapp/MainActivity.kt
@@ -88,7 +88,7 @@ class MainActivity : AppCompatActivity(), HyperInterface {
 
                         val publishableKey  = json.getString("publishableKey")
                         val sdkAuthorization = json.getString("sdkAuthorization")
-                        val profileId       = json.optString("profileId")
+                        val profileId       = json.optString("profileId").takeIf { it.isNotEmpty() }
 
                         hyperswitchInstance = Hyperswitch.init(
                             activity = this@MainActivity,

--- a/demo-app/src/main/kotlin/io/hyperswitch/demoapp/WidgetActivity.kt
+++ b/demo-app/src/main/kotlin/io/hyperswitch/demoapp/WidgetActivity.kt
@@ -65,7 +65,7 @@ class WidgetActivity : AppCompatActivity(), HyperInterface {
                     try {
                         val json = JSONObject(value ?: return)
                         val publishableKey  = json.getString("publishableKey")
-                        val profileId       = json.optString("profileId")
+                        val profileId       = json.optString("profileId").takeIf { it.isNotEmpty() }
                         sdkAuthorization    = json.getString("sdkAuthorization")
                         paymentId           = json.optString("paymentId")
 
@@ -108,7 +108,7 @@ class WidgetActivity : AppCompatActivity(), HyperInterface {
 
     // ── Initialisation ─────────────────────────────────────────────────────────────────────────
 
-    private fun initialiseWidgets(publishableKey: String, profileId: String) {
+    private fun initialiseWidgets(publishableKey: String, profileId: String?) {
         hyperswitchInstance = Hyperswitch.init(
             activity = this,
             config = HyperswitchConfiguration(

--- a/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/PaymentConfiguration.kt
+++ b/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/PaymentConfiguration.kt
@@ -16,6 +16,7 @@ data class PaymentConfiguration
     val customBackendUrl: String? = null,
     val customLogUrl: String? = null,
     val customParams: Bundle? = null,
+    val profileId: String? = null,
 ) : Parcelable {
 
     /**
@@ -31,12 +32,14 @@ data class PaymentConfiguration
             stripeAccountId: String?,
             customBackendUrl: String?,
             customLogUrl: String?,
+            profileId: String?,
         ) {
             prefs.edit {
                 putString(KEY_PUBLISHABLE_KEY, publishableKey)
                     .putString(KEY_ACCOUNT_ID, stripeAccountId)
                     .putString(KEY_CUSTOM_BACKEND_URL, customBackendUrl)
                     .putString(KEY_CUSTOM_LOG_URL, customLogUrl)
+                    .putString(KEY_PROFILE_ID, profileId)
             }
         }
 
@@ -48,6 +51,7 @@ data class PaymentConfiguration
                     stripeAccountId = prefs.getString(KEY_ACCOUNT_ID, null),
                     customBackendUrl = prefs.getString(KEY_CUSTOM_BACKEND_URL, null),
                     customLogUrl = prefs.getString(KEY_CUSTOM_LOG_URL, null),
+                    profileId = prefs.getString(KEY_PROFILE_ID, null),
                 )
             }
         }
@@ -59,6 +63,7 @@ data class PaymentConfiguration
             private const val KEY_ACCOUNT_ID = "key_account_id"
             private const val KEY_CUSTOM_BACKEND_URL = "key_custom_backend_url"
             private const val KEY_CUSTOM_LOG_URL = "key_custom_log_url"
+            private const val KEY_PROFILE_ID = "key_profile_id"
         }
     }
 
@@ -95,6 +100,10 @@ data class PaymentConfiguration
             return instance?.publishableKey ?: ""
         }
 
+        fun profileId(): String? {
+            return instance?.profileId
+        }
+
         val customBackendUrl: String? = instance?.customBackendUrl
         val customLogUrl: String? = instance?.customLogUrl
         val customParams: Bundle? = instance?.customParams
@@ -110,20 +119,23 @@ data class PaymentConfiguration
             stripeAccountId: String? = null,
             customBackendUrl: String? = null,
             customLogUrl: String? = null,
-            customParams: Bundle? = null
+            customParams: Bundle? = null,
+            profileId: String? = null,
         ) {
             instance = PaymentConfiguration(
                 publishableKey = publishableKey,
                 stripeAccountId = stripeAccountId,
                 customBackendUrl = customBackendUrl,
                 customLogUrl = customLogUrl,
-                customParams = customParams
+                customParams = customParams,
+                profileId = profileId,
             )
             Store(context).save(
                 publishableKey = publishableKey,
                 stripeAccountId = stripeAccountId,
                 customBackendUrl = customBackendUrl,
-                customLogUrl = customLogUrl
+                customLogUrl = customLogUrl,
+                profileId = profileId,
             )
         }
 

--- a/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsession/BasePaymentSessionLauncher.kt
+++ b/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsession/BasePaymentSessionLauncher.kt
@@ -12,19 +12,21 @@ abstract class BasePaymentSessionLauncher(
     publishableKey: String?,
     customBackendUrl: String?,
     customLogUrl: String?,
-    customParams: Bundle?
+    customParams: Bundle?,
+    profileId: String? = null,
 ) : PaymentSessionLauncher {
 
     protected var sdkAuthorization: String? = null
 
     init {
         PaymentConfiguration.init(
-            activity.applicationContext,
-            publishableKey,
-            "",
-            customBackendUrl,
-            customLogUrl,
-            customParams
+            context = activity.applicationContext,
+            publishableKey = publishableKey,
+            stripeAccountId = "",
+            customBackendUrl = customBackendUrl,
+            customLogUrl = customLogUrl,
+            customParams = customParams,
+            profileId = profileId,
         )
     }
 

--- a/hyperswitch-sdk-android-lite/src/main/kotlin/io/hyperswitch/PaymentSession.kt
+++ b/hyperswitch-sdk-android-lite/src/main/kotlin/io/hyperswitch/PaymentSession.kt
@@ -15,29 +15,14 @@ import io.hyperswitch.paymentsheet.PaymentResult
  * and retrieving customer saved payment methods.
  */
 class PaymentSession internal constructor(private val paymentSessionLauncher: PaymentSessionLauncher) {
-    constructor(activity: Activity, publishableKey: String) : this(
-        DefaultPaymentSessionLauncherLite(activity, publishableKey, null, null, null)
+    constructor(activity: Activity, publishableKey: String, profileId: String? = null) : this(
+        DefaultPaymentSessionLauncherLite(activity, publishableKey, null, null, null, profileId)
     )
 
     constructor(
-        activity: Activity, publishableKey: String, customBackendUrl: String
+        activity: Activity, publishableKey: String, customBackendUrl: String, profileId: String? = null
     ) : this(
-        DefaultPaymentSessionLauncherLite(activity, publishableKey, customBackendUrl, null, null)
-    )
-
-    constructor(
-        activity: Activity,
-        publishableKey: String,
-        customBackendUrl: String,
-        customLogUrl: String
-    ) : this(
-        DefaultPaymentSessionLauncherLite(
-            activity, publishableKey, customBackendUrl, customLogUrl, null
-        )
-    )
-
-    constructor(activity: Activity, publishableKey: String, customParams: Bundle) : this(
-        DefaultPaymentSessionLauncherLite(activity, publishableKey, null, null, customParams)
+        DefaultPaymentSessionLauncherLite(activity, publishableKey, customBackendUrl, null, null, profileId)
     )
 
     constructor(
@@ -45,10 +30,27 @@ class PaymentSession internal constructor(private val paymentSessionLauncher: Pa
         publishableKey: String,
         customBackendUrl: String,
         customLogUrl: String,
-        customParams: Bundle
+        profileId: String? = null,
     ) : this(
         DefaultPaymentSessionLauncherLite(
-            activity, publishableKey, customBackendUrl, customLogUrl, customParams
+            activity, publishableKey, customBackendUrl, customLogUrl, null, profileId
+        )
+    )
+
+    constructor(activity: Activity, publishableKey: String, customParams: Bundle, profileId: String? = null) : this(
+        DefaultPaymentSessionLauncherLite(activity, publishableKey, null, null, customParams, profileId)
+    )
+
+    constructor(
+        activity: Activity,
+        publishableKey: String,
+        customBackendUrl: String,
+        customLogUrl: String,
+        customParams: Bundle,
+        profileId: String? = null,
+    ) : this(
+        DefaultPaymentSessionLauncherLite(
+            activity, publishableKey, customBackendUrl, customLogUrl, customParams, profileId
         )
     )
 
@@ -61,14 +63,16 @@ class PaymentSession internal constructor(private val paymentSessionLauncher: Pa
         private var customBackendUrl: String? = null
         private var customLogUrl: String? = null
         private var customParams: Bundle? = null
+        private var profileId: String? = null
 
         fun customBackendUrl(url: String) = apply { this.customBackendUrl = url }
         fun customLogUrl(url: String) = apply { this.customLogUrl = url }
         fun customParams(params: Bundle) = apply { this.customParams = params }
+        fun profileId(profileId: String?) = apply { this.profileId = profileId }
 
         fun build(): PaymentSession {
             val launcher = DefaultPaymentSessionLauncherLite(
-                activity, publishableKey, customBackendUrl, customLogUrl, customParams
+                activity, publishableKey, customBackendUrl, customLogUrl, customParams, profileId
             )
             return PaymentSession(launcher)
         }

--- a/hyperswitch-sdk-android-lite/src/main/kotlin/io/hyperswitch/lite/DefaultPaymentSessionLauncherLite.kt
+++ b/hyperswitch-sdk-android-lite/src/main/kotlin/io/hyperswitch/lite/DefaultPaymentSessionLauncherLite.kt
@@ -16,13 +16,15 @@ open class DefaultPaymentSessionLauncherLite(
     customBackendUrl: String?,
     customLogUrl: String?,
     customParams: Bundle?,
+    profileId: String? = null,
     private val webViewUtils: SDKInterface = WebViewUtils(activity)
 ) : BasePaymentSessionLauncher(
     activity,
     publishableKey,
     customBackendUrl,
     customLogUrl,
-    customParams
+    customParams,
+    profileId,
 ) {
 
     override fun presentPaymentSheet(


### PR DESCRIPTION
## Summary
 - Replaces the abandoned #80 with the optional-profileId variant. profileId becomes `String? = null` everywhere in the payment-session flow; click-to-pay and authentication are deliberately excluded.

  ## Why
- After #80 was opened to make profileId mandatory across PaymentSession, product decided profileId should be inferred from the publishable key on the backend when not supplied. Forcing merchants to pass it is now a regression on integration ergonomics.