### PR TITLE
fix: improve fragment lifecycle management and enhance update intent handling

### DIFF
--- a/app/src/main/kotlin/io/hyperswitch/react/HyperFragment.kt
+++ b/app/src/main/kotlin/io/hyperswitch/react/HyperFragment.kt
@@ -83,6 +83,10 @@ class HyperFragment : ReactFragment() {
             callback?.invoke()
             return
         }
+        if (callbacks[CallbackType.UPDATE_INTENT_INIT] != null) {
+            callback?.invoke()
+            return
+        }
         callbacks[CallbackType.UPDATE_INTENT_INIT] = HyperCallback.UpdateIntentInit(callback)
         reactNativeHost.reactInstanceManager.currentReactContext
             ?.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
@@ -349,6 +353,9 @@ class HyperFragment : ReactFragment() {
     override fun onDestroyView() {
         try {
             super.onDestroyView()
+            callbacks.clear()
+            onExit = null
+            paymentEventListener = null
         }catch(_: Exception){}
     }
 
@@ -357,6 +364,8 @@ class HyperFragment : ReactFragment() {
             super.onDestroy()
             unRegisterEventBus()
             callbacks.clear()
+            onExit = null
+            paymentEventListener = null
         }catch(_ : Exception){}
     }
 

--- a/app/src/main/kotlin/io/hyperswitch/react/HyperFragmentManager.kt
+++ b/app/src/main/kotlin/io/hyperswitch/react/HyperFragmentManager.kt
@@ -75,13 +75,21 @@ object HyperFragmentManager {
         tag: String,
         addToBackStack: Boolean
     ) {
-        val fm: FragmentManager = activity.supportFragmentManager
+        try {
+            if (activity.isFinishing || activity.isDestroyed) return
+            if (container.parent == null || !container.isAttachedToWindow) return
+            if (fragment.isAdded) return
+
+            val fm: FragmentManager = activity.supportFragmentManager
 
         // Remove existing fragment with the same tag if present, including its back-stack entry
         // so that onDestroy is called and the React tree is fully released.
         val existing = fm.findFragmentByTag(tag)
         if (existing != null) {
             fm.popBackStackImmediate(tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+            if (existing.isAdded) {
+                fm.beginTransaction().remove(existing).commitNowAllowingStateLoss()
+            }
             fragmentRegistry.remove(tag)
         }
 
@@ -91,9 +99,12 @@ object HyperFragmentManager {
 
         val tx = fm.beginTransaction().add(container.id, fragment, tag)
         if (addToBackStack) tx.addToBackStack(tag)
-        tx.commitAllowingStateLoss()
+        tx.commitNowAllowingStateLoss()
 
-        fragmentRegistry[tag] = fragment
+            fragmentRegistry[tag] = fragment
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
     }
 
     /**
@@ -115,7 +126,7 @@ object HyperFragmentManager {
             fm.popBackStackImmediate(tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
             // If still attached (was never on the back stack), remove it directly.
             if (fragment.isAdded) {
-                fm.beginTransaction().remove(fragment).commitAllowingStateLoss()
+                fm.beginTransaction().remove(fragment).commitNowAllowingStateLoss()
             }
         }
         fragmentRegistry.remove(tag)

--- a/app/src/main/kotlin/io/hyperswitch/sdk/Elements.kt
+++ b/app/src/main/kotlin/io/hyperswitch/sdk/Elements.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.resume
 
 class Elements internal constructor(
@@ -59,15 +60,33 @@ class Elements internal constructor(
         return hsElement
     }
 
-    suspend fun updateIntent(completion: suspend () -> PaymentSessionConfiguration): ElementsUpdateResult =
-        computeUpdateIntent(hsElements.toList(), completion)
+    fun unbind(boundElement: HyperswitchBoundElement) {
+        hsElements.remove(boundElement)
+    }
+
+    private val updateIntentInProgress = AtomicBoolean(false)
+
+    suspend fun updateIntent(completion: suspend () -> PaymentSessionConfiguration): ElementsUpdateResult {
+        if (!updateIntentInProgress.compareAndSet(false, true)) {
+            return ElementsUpdateResult.TotalFailure(
+                IllegalStateException("updateIntent already in progress").apply {
+                    initCause(Throwable("ALREADY_IN_PROGRESS"))
+                }
+            )
+        }
+        try {
+            return computeUpdateIntent(hsElements.toList(), completion)
+        } finally {
+            updateIntentInProgress.set(false)
+        }
+    }
 
     fun updateIntent(
         completion: suspend () -> PaymentSessionConfiguration,
         onResult: (ElementsUpdateResult) -> Unit
     ) {
         scope.launch {
-            onResult(computeUpdateIntent(hsElements.toList(), completion))
+            onResult(updateIntent(completion))
         }
     }
 
@@ -76,7 +95,6 @@ class Elements internal constructor(
         completion: suspend () -> PaymentSessionConfiguration
     ): ElementsUpdateResult {
         if (targets.isEmpty()) return ElementsUpdateResult.Success
-
         val initResults: List<Pair<HyperswitchBoundElement, Result<Unit>>> = coroutineScope {
             targets.map { hsElement ->
                 async {

--- a/app/src/main/kotlin/io/hyperswitch/sdk/HyperswitchBoundElement.kt
+++ b/app/src/main/kotlin/io/hyperswitch/sdk/HyperswitchBoundElement.kt
@@ -75,4 +75,8 @@ class HyperswitchBoundElement internal constructor(
     suspend fun updateIntentComplete(sdkAuthorization: String): ElementUpdateIntentResult {
         return element.updateIntentComplete(sdkAuthorization)
     }
+
+    fun destroy() {
+        element.onPaymentResult(PaymentResultListener { /* disposed - no-op */ })
+    }
 }

--- a/app/src/main/kotlin/io/hyperswitch/view/HyperswitchElement.kt
+++ b/app/src/main/kotlin/io/hyperswitch/view/HyperswitchElement.kt
@@ -158,4 +158,8 @@ open class HyperswitchElement @JvmOverloads constructor(
             }
         }
     }
+
+    fun destroy() {
+        internalView.removeWidget()
+    }
 }

--- a/app/src/main/kotlin/io/hyperswitch/view/PaymentWidgetView.kt
+++ b/app/src/main/kotlin/io/hyperswitch/view/PaymentWidgetView.kt
@@ -86,11 +86,14 @@ class PaymentWidgetView : FrameLayout {
 //        initWidget( ?: "")
         // Auto-show widget if SDK authorization is already set
         if (!isSdkAuthorizationEmpty()) {
-            showWidgetInternal()
+            post { showWidgetInternal() }
         }
     }
 
     private fun init(context: Context) {
+        if (id == NO_ID) {
+            id = generateViewId()
+        }
         this.mContext = context
         launchOptions = LaunchOptions(context.applicationContext, BuildConfig.VERSION_NAME)
         this.publishableKey = PaymentConfiguration.publishableKey()
@@ -376,7 +379,9 @@ class PaymentWidgetView : FrameLayout {
             val activity = context as? FragmentActivity ?: return
             val tag = "HyperPaymentSheet_${this.id}"
             HyperFragmentManager.remove(activity, tag)
-            removeAllViews()
+            post {
+                removeAllViews()
+            }
             widgetShown = false
         } catch (_: Exception) {
             // Handle the errors


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the fragment and element lifecycle management, concurrency handling, and view initialization in the Hyperswitch SDK. The changes focus on making fragment removal and view cleanup more robust, preventing concurrent update operations, and ensuring safe initialization and destruction of UI components.

**Fragment and View Lifecycle Management:**
- Improved cleanup in `HyperFragment` by clearing callbacks and nullifying listeners in both `onDestroyView` and `onDestroy` to avoid memory leaks and dangling references. [[1]](diffhunk://#diff-d05d00a519538ac4dbb694f21f064699160827dee6b0ef97f79f46d66805fbf1R356-R358) [[2]](diffhunk://#diff-d05d00a519538ac4dbb694f21f064699160827dee6b0ef97f79f46d66805fbf1R367-R368)
- In `PaymentWidgetView`, ensured that widget removal and view cleanup are posted to the UI thread, and that the view has a valid ID during initialization. [[1]](diffhunk://#diff-247d6689a35b47818751b657ec0f0e336c2c047f0fe8c8e3f04177126a22bdd0L89-R96) [[2]](diffhunk://#diff-247d6689a35b47818751b657ec0f0e336c2c047f0fe8c8e3f04177126a22bdd0R382-R384)

**Concurrency and State Management:**
- Added an `AtomicBoolean` in `Elements` to prevent concurrent calls to `updateIntent`, returning a failure result if an update is already in progress.

**Fragment Transaction Robustness:**
- Wrapped fragment addition logic in `HyperFragmentManager` with additional checks (e.g., activity state, container attachment) and exception handling to prevent crashes, and switched to `commitNowAllowingStateLoss` for immediate transaction execution. [[1]](diffhunk://#diff-2b8f6cccd226106a751bf6dc4426f6effeb4c49b065566e9cd20408d527039b8R78-R92) [[2]](diffhunk://#diff-2b8f6cccd226106a751bf6dc4426f6effeb4c49b065566e9cd20408d527039b8L94-R107) [[3]](diffhunk://#diff-2b8f6cccd226106a751bf6dc4426f6effeb4c49b065566e9cd20408d527039b8L118-R129)

**Element and Widget Destruction:**
- Added `destroy()` methods to `HyperswitchBoundElement` and `HyperswitchElement` to ensure proper disposal and cleanup of resources. [[1]](diffhunk://#diff-49664b84fb61b8603c5879a092ca732030e4b42fbdaab01ab1224fa3200ce014R78-R81) [[2]](diffhunk://#diff-51cd9b729443364726fc48036fe8f8e60277bf8f7c31e372ad0a0373c3efac44R161-R164)

**Other Notable Improvements:**
- Added an early exit in the callback invocation logic of `HyperFragment` to avoid redundant initialization.
- Introduced an `unbind` method in `Elements` for removing bound elements.

These changes collectively improve the stability, reliability, and maintainability of the SDK, especially around fragment and view lifecycle events, and concurrent operations.