### PR TITLE
feat: add payment confirm button callback and related functionality

### DIFF
--- a/app/src/main/kotlin/io/hyperswitch/react/HyperFragment.kt
+++ b/app/src/main/kotlin/io/hyperswitch/react/HyperFragment.kt
@@ -42,7 +42,8 @@ enum class CallbackType {
     CONFIRM_ACTION,
     CONFIRM_CVC_ACTION,
     UPDATE_INTENT_INIT,
-    UPDATE_INTENT_COMPLETE
+    UPDATE_INTENT_COMPLETE,
+    CONFIRM_BUTTON_TRIGGERED
 }
 
 
@@ -50,6 +51,9 @@ sealed class HyperCallback {
     class Payment(val fn: ((PaymentResult) -> Unit)) : HyperCallback()
     class UpdateIntentInit(val fn: (() -> Unit)?) : HyperCallback()
     class UpdateIntentComplete(val fn: ((ElementUpdateIntentResult) -> Unit)) : HyperCallback()
+    class ConfirmButtonTriggered(
+        val callback: (data: String, onPaymentResultCallback: (Boolean) -> Unit) -> Unit,
+    ) : HyperCallback()
 }
 
 class HyperFragment : ReactFragment() {
@@ -71,6 +75,12 @@ class HyperFragment : ReactFragment() {
 
     fun setOnPaymentResult(callback: ((PaymentResult) -> Unit)) {
         callbacks[CallbackType.PAYMENT_RESULT] = HyperCallback.Payment(callback)
+    }
+
+    fun setOnPaymentConfirmButtonCallback(callback: (data: String, onPaymentResultCallback: ((Boolean) -> Unit)) -> Unit) {
+        callbacks[CallbackType.CONFIRM_BUTTON_TRIGGERED] = HyperCallback.ConfirmButtonTriggered(
+            callback
+        )
     }
 
     fun setOnEventCallback(listener: PaymentEventListener) {
@@ -199,6 +209,7 @@ class HyperFragment : ReactFragment() {
 
                 CallbackType.UPDATE_INTENT_INIT ->
                     (callbacks.remove(CallbackType.UPDATE_INTENT_INIT) as? HyperCallback.UpdateIntentInit)?.fn?.invoke()
+
                 CallbackType.UPDATE_INTENT_COMPLETE ->
                     (callbacks.remove(CallbackType.UPDATE_INTENT_COMPLETE) as? HyperCallback.UpdateIntentComplete)?.fn?.invoke(
                         parseElementUpdateResult(result)
@@ -223,6 +234,13 @@ class HyperFragment : ReactFragment() {
         } catch (e: Exception) {
             Log.e("HyperFragment", "Error in notifyResult", e)
         }
+    }
+
+    fun notifyConfirmButtonTriggered(payload: String, callback: (Boolean) -> Unit) {
+        val confirmTriggeredCallback =
+            callbacks[CallbackType.CONFIRM_BUTTON_TRIGGERED] as HyperCallback.ConfirmButtonTriggered?
+        confirmTriggeredCallback?.callback?.invoke(payload, callback)
+        callbacks.remove(CallbackType.CONFIRM_ACTION)
     }
 
     private fun parseElementUpdateResult(data: String): ElementUpdateIntentResult {
@@ -251,6 +269,7 @@ class HyperFragment : ReactFragment() {
                 throwable.initCause(Throwable(jsonObject.getString("code")))
                 PaymentResult.Failed(throwable)
             }
+
             else -> PaymentResult.Completed(status)
         }
         return result
@@ -356,7 +375,8 @@ class HyperFragment : ReactFragment() {
             callbacks.clear()
             onExit = null
             paymentEventListener = null
-        }catch(_: Exception){}
+        } catch (_: Exception) {
+        }
     }
 
     override fun onDestroy() {
@@ -366,13 +386,15 @@ class HyperFragment : ReactFragment() {
             callbacks.clear()
             onExit = null
             paymentEventListener = null
-        }catch(_ : Exception){}
+        } catch (_: Exception) {
+        }
     }
 
     override fun onPause() {
         try {
             super.onPause()
-        }catch(_: Exception){}
+        } catch (_: Exception) {
+        }
     }
 
     // ── Scroll fix ────────────────────────────────────────────────────────────

--- a/app/src/main/kotlin/io/hyperswitch/react/HyperFragment.kt
+++ b/app/src/main/kotlin/io/hyperswitch/react/HyperFragment.kt
@@ -43,7 +43,7 @@ enum class CallbackType {
     CONFIRM_CVC_ACTION,
     UPDATE_INTENT_INIT,
     UPDATE_INTENT_COMPLETE,
-    CONFIRM_BUTTON_CLICK
+    PAYMENT_CONFIRM_BUTTON_CLICK
 }
 
 
@@ -78,7 +78,7 @@ class HyperFragment : ReactFragment() {
     }
 
     fun setOnPaymentConfirmButtonClick(callback: (data: String, onPaymentResultCallback: ((Boolean) -> Unit)) -> Unit) {
-        callbacks[CallbackType.CONFIRM_BUTTON_CLICK] = HyperCallback.ConfirmButtonTriggered(
+        callbacks[CallbackType.PAYMENT_CONFIRM_BUTTON_CLICK] = HyperCallback.ConfirmButtonTriggered(
             callback
         )
     }
@@ -238,8 +238,12 @@ class HyperFragment : ReactFragment() {
 
     fun notifyConfirmButtonClicked(payload: String, callback: (Boolean) -> Unit) {
         val confirmTriggeredCallback =
-            callbacks[CallbackType.CONFIRM_BUTTON_CLICK] as HyperCallback.ConfirmButtonTriggered?
-        confirmTriggeredCallback?.callback?.invoke(payload, callback)
+            callbacks[CallbackType.PAYMENT_CONFIRM_BUTTON_CLICK] as HyperCallback.ConfirmButtonTriggered?
+        if(confirmTriggeredCallback == null){
+            callback.invoke(true)
+        }else {
+            confirmTriggeredCallback.callback.invoke(payload, callback)
+        }
         callbacks.remove(CallbackType.CONFIRM_ACTION)
     }
 

--- a/app/src/main/kotlin/io/hyperswitch/react/HyperFragment.kt
+++ b/app/src/main/kotlin/io/hyperswitch/react/HyperFragment.kt
@@ -43,7 +43,7 @@ enum class CallbackType {
     CONFIRM_CVC_ACTION,
     UPDATE_INTENT_INIT,
     UPDATE_INTENT_COMPLETE,
-    CONFIRM_BUTTON_TRIGGERED
+    CONFIRM_BUTTON_CLICK
 }
 
 
@@ -77,8 +77,8 @@ class HyperFragment : ReactFragment() {
         callbacks[CallbackType.PAYMENT_RESULT] = HyperCallback.Payment(callback)
     }
 
-    fun setOnPaymentConfirmButtonCallback(callback: (data: String, onPaymentResultCallback: ((Boolean) -> Unit)) -> Unit) {
-        callbacks[CallbackType.CONFIRM_BUTTON_TRIGGERED] = HyperCallback.ConfirmButtonTriggered(
+    fun setOnPaymentConfirmButtonClick(callback: (data: String, onPaymentResultCallback: ((Boolean) -> Unit)) -> Unit) {
+        callbacks[CallbackType.CONFIRM_BUTTON_CLICK] = HyperCallback.ConfirmButtonTriggered(
             callback
         )
     }
@@ -236,9 +236,9 @@ class HyperFragment : ReactFragment() {
         }
     }
 
-    fun notifyConfirmButtonTriggered(payload: String, callback: (Boolean) -> Unit) {
+    fun notifyConfirmButtonClicked(payload: String, callback: (Boolean) -> Unit) {
         val confirmTriggeredCallback =
-            callbacks[CallbackType.CONFIRM_BUTTON_TRIGGERED] as HyperCallback.ConfirmButtonTriggered?
+            callbacks[CallbackType.CONFIRM_BUTTON_CLICK] as HyperCallback.ConfirmButtonTriggered?
         confirmTriggeredCallback?.callback?.invoke(payload, callback)
         callbacks.remove(CallbackType.CONFIRM_ACTION)
     }

--- a/app/src/main/kotlin/io/hyperswitch/react/HyperModule.kt
+++ b/app/src/main/kotlin/io/hyperswitch/react/HyperModule.kt
@@ -63,10 +63,10 @@ class HyperModule internal constructor(private val rct: ReactApplicationContext)
      * Stores the callback; native later calls [resolveConfirmCallback] to proceed/abort.
      */
     @ReactMethod
-    fun onPaymentConfirmButtonCallback(rootTag: Double, payload: String, callback: Callback) {
+    fun onPaymentConfirmButtonClick(rootTag: Double, payload: String, callback: Callback) {
         findViewWithRootTag(rootTag.toInt()) {
             try {
-                it?.notifyConfirmButtonTriggered(payload, { it: Boolean ->
+                it?.notifyConfirmButtonClicked(payload, { it: Boolean ->
                     callback.invoke(it)
                 })
             } catch (_: Exception) {

--- a/app/src/main/kotlin/io/hyperswitch/react/HyperModule.kt
+++ b/app/src/main/kotlin/io/hyperswitch/react/HyperModule.kt
@@ -58,6 +58,23 @@ class HyperModule internal constructor(private val rct: ReactApplicationContext)
         // Express checkout widget height adjustment is not yet implemented.
     }
 
+    /**
+     * Called from JS when a wallet confirm button is tapped.
+     * Stores the callback; native later calls [resolveConfirmCallback] to proceed/abort.
+     */
+    @ReactMethod
+    fun onPaymentConfirmButtonCallback(rootTag: Double, payload: String, callback: Callback) {
+        findViewWithRootTag(rootTag.toInt()) {
+            try {
+                it?.notifyConfirmButtonTriggered(payload, { it: Boolean ->
+                    callback.invoke(it)
+                })
+            } catch (_: Exception) {
+                callback.invoke(false)
+            }
+        }
+    }
+
     @ReactMethod
     fun sendMessageToNative(rnMessage: String) {
         val jsonObject = JSONObject(rnMessage)
@@ -135,16 +152,19 @@ class HyperModule internal constructor(private val rct: ReactApplicationContext)
     // Method to exit widget payment sheet
     @ReactMethod
     fun exitWidgetPaymentsheet(rootTag: Double, paymentResult: String, reset: Boolean) {
-        findFragmentWithRootTag(rootTag.toInt(), {
+        findViewWithRootTag(rootTag.toInt(), {
             it?.notifyResult(CallbackType.PAYMENT_RESULT, paymentResult)
         })
     }
 
     @ReactMethod
     fun notifyWidgetPaymentResult(rootTag: Double, result: String) {
-        findFragmentWithRootTag(rootTag.toInt(), { fragment ->
+        findViewWithRootTag(rootTag.toInt(), { fragment ->
             if (fragment == null) {
-                Log.w("HyperModule", "notifyWidgetPaymentResult: no fragment found for rootTag=$rootTag")
+                Log.w(
+                    "HyperModule",
+                    "notifyWidgetPaymentResult: no fragment found for rootTag=$rootTag"
+                )
             } else {
                 fragment.notifyResult(CallbackType.CONFIRM_ACTION, result)
             }
@@ -153,10 +173,10 @@ class HyperModule internal constructor(private val rct: ReactApplicationContext)
 
     @ReactMethod
     fun onUpdateIntentEvent(rootTag: Double, type: String, result: String) {
-        findFragmentWithRootTag(rootTag.toInt(), { fragment ->
+        findViewWithRootTag(rootTag.toInt(), { fragment ->
             if (fragment == null) {
                 Log.w("HyperModule", "onUpdateIntentEvent: no fragment found for rootTag=$rootTag")
-                return@findFragmentWithRootTag
+                return@findViewWithRootTag
             }
             if (type == "UPDATE_INTENT_INIT_RETURNED") {
                 fragment.notifyResult(CallbackType.UPDATE_INTENT_INIT, result)
@@ -165,6 +185,7 @@ class HyperModule internal constructor(private val rct: ReactApplicationContext)
             }
         })
     }
+
     // Variable to keep track of event listener count
     private val listenerCount = AtomicInteger(0)
 
@@ -177,7 +198,7 @@ class HyperModule internal constructor(private val rct: ReactApplicationContext)
         }
     }
 
-// Method to remove event listeners
+    // Method to remove event listeners
     @ReactMethod
     fun removeListeners(count: Int) {
         listenerCount.addAndGet(-count)
@@ -185,7 +206,7 @@ class HyperModule internal constructor(private val rct: ReactApplicationContext)
 
     @ReactMethod
     fun emitPaymentEvent(rootTag: Double, eventType: String, payload: ReadableMap) {
-        findFragmentWithRootTag(rootTag.toInt(), { fragment ->
+        findViewWithRootTag(rootTag.toInt(), { fragment ->
             if (fragment == null) {
                 Log.w("HyperModule", "emitPaymentEvent: no fragment found for rootTag=$rootTag")
             } else {
@@ -194,7 +215,7 @@ class HyperModule internal constructor(private val rct: ReactApplicationContext)
         })
     }
 
-    private fun findFragmentWithRootTag(rootTag: Int, onFound: (HyperFragment?) -> Unit) {
+    private fun findViewWithRootTag(rootTag: Int, onFound: (HyperFragment?) -> Unit) {
         val uiManagerModule =
             reactApplicationContext.getNativeModule<UIManagerModule?>(UIManagerModule::class.java)
 

--- a/app/src/main/kotlin/io/hyperswitch/react/HyperModule.kt
+++ b/app/src/main/kotlin/io/hyperswitch/react/HyperModule.kt
@@ -66,9 +66,13 @@ class HyperModule internal constructor(private val rct: ReactApplicationContext)
     fun onPaymentConfirmButtonClick(rootTag: Double, payload: String, callback: Callback) {
         findViewWithRootTag(rootTag.toInt()) {
             try {
-                it?.notifyConfirmButtonClicked(payload, { it: Boolean ->
-                    callback.invoke(it)
-                })
+                if(it == null){
+                    callback.invoke(true)
+                }else {
+                    it.notifyConfirmButtonClicked(payload, { it: Boolean ->
+                        callback.invoke(it)
+                    })
+                }
             } catch (_: Exception) {
                 callback.invoke(false)
             }

--- a/app/src/main/kotlin/io/hyperswitch/sdk/HyperswitchBoundElement.kt
+++ b/app/src/main/kotlin/io/hyperswitch/sdk/HyperswitchBoundElement.kt
@@ -59,12 +59,12 @@ class HyperswitchBoundElement internal constructor(
         element.onPaymentResult(onResult)
     }
 
-    fun onPaymentConfirmButton(
+    fun onPaymentConfirmButtonClick(
         onConfirmButtonClick:
             (data: PaymentRequestData?,
-             onPaymentResultCallback: (Boolean) -> Unit)
+             onConfirmPaymentCallback: (Boolean) -> Unit)
         -> Unit){
-        element.onPaymentConfirmButtonCallback(onConfirmButtonClick)
+        element.onPaymentConfirmButtonClick(onConfirmButtonClick)
     }
 
     suspend fun confirmPayment(): PaymentResult {

--- a/app/src/main/kotlin/io/hyperswitch/sdk/HyperswitchBoundElement.kt
+++ b/app/src/main/kotlin/io/hyperswitch/sdk/HyperswitchBoundElement.kt
@@ -2,6 +2,7 @@ package io.hyperswitch.sdk
 
 import io.hyperswitch.PaymentEventSubscriptionBuilder
 import io.hyperswitch.model.ElementUpdateIntentResult
+import io.hyperswitch.paymentsheet.PaymentRequestData
 import io.hyperswitch.paymentsheet.PaymentResult
 import io.hyperswitch.paymentsheet.PaymentSheet
 import io.hyperswitch.utils.ConversionUtils
@@ -56,6 +57,14 @@ class HyperswitchBoundElement internal constructor(
 
     fun onPaymentResult(onResult: (PaymentResult) -> Unit) {
         element.onPaymentResult(onResult)
+    }
+
+    fun onPaymentConfirmButton(
+        onConfirmButtonClick:
+            (data: PaymentRequestData?,
+             onPaymentResultCallback: (Boolean) -> Unit)
+        -> Unit){
+        element.onPaymentConfirmButtonCallback(onConfirmButtonClick)
     }
 
     suspend fun confirmPayment(): PaymentResult {

--- a/app/src/main/kotlin/io/hyperswitch/view/HyperswitchElement.kt
+++ b/app/src/main/kotlin/io/hyperswitch/view/HyperswitchElement.kt
@@ -80,8 +80,8 @@ open class HyperswitchElement @JvmOverloads constructor(
     }
 
 
-    fun onPaymentConfirmButtonCallback(callback: (data: PaymentRequestData?, onPaymentResultCallback: (Boolean) -> Unit) -> Unit){
-        internalView.onPaymentConfirmButtonCallback(callback)
+    fun onPaymentConfirmButtonClick(callback: (data: PaymentRequestData?, onConfirmPaymentCallback: (Boolean) -> Unit) -> Unit){
+        internalView.onPaymentConfirmButtonClick(callback)
     }
 
     /**

--- a/app/src/main/kotlin/io/hyperswitch/view/HyperswitchElement.kt
+++ b/app/src/main/kotlin/io/hyperswitch/view/HyperswitchElement.kt
@@ -6,6 +6,7 @@ import android.widget.FrameLayout
 import com.facebook.react.bridge.ReadableMap
 import io.hyperswitch.PaymentEventListener
 import io.hyperswitch.model.ElementUpdateIntentResult
+import io.hyperswitch.paymentsheet.PaymentRequestData
 import io.hyperswitch.paymentsheet.PaymentResult
 import io.hyperswitch.paymentsheet.PaymentSheet
 import kotlinx.coroutines.CoroutineScope
@@ -76,6 +77,11 @@ open class HyperswitchElement @JvmOverloads constructor(
      */
     fun confirmPayment(callback: (PaymentResult) -> Unit) {
         internalView.confirmPayment(callback)
+    }
+
+
+    fun onPaymentConfirmButtonCallback(callback: (data: PaymentRequestData?, onPaymentResultCallback: (Boolean) -> Unit) -> Unit){
+        internalView.onPaymentConfirmButtonCallback(callback)
     }
 
     /**

--- a/app/src/main/kotlin/io/hyperswitch/view/PaymentWidgetView.kt
+++ b/app/src/main/kotlin/io/hyperswitch/view/PaymentWidgetView.kt
@@ -46,7 +46,7 @@ fun interface PaymentResultListener {
     fun onPaymentResult(result: PaymentResult)
 }
 
-fun interface ConfirmPaymentCallbackListener {
+fun interface ConfirmPaymentClickListener {
     fun onConfirmPaymentCallback(data: String, onPaymentResultCallback: (Boolean) -> Unit)
 }
 
@@ -67,7 +67,7 @@ class PaymentWidgetView : FrameLayout {
 
     private var resultListener: PaymentResultListener? = null
 
-    private var confirmPaymentListener: ConfirmPaymentCallbackListener? = null
+    private var confirmPaymentClickListener: ConfirmPaymentClickListener? = null
     private var subscribedEvents: List<String> = emptyList()
 
     private var onEventCallback: PaymentEventListener? = null
@@ -215,37 +215,37 @@ class PaymentWidgetView : FrameLayout {
         resultListener?.onPaymentResult(result)
     }
 
-    fun onPaymentConfirmButtonCallback(
+    fun onPaymentConfirmButtonClick(
         callback: (
             data: PaymentRequestData?,
             onPaymentResultCallback: (Boolean) -> Unit
         ) -> Unit
     ) {
-        confirmPaymentListener = ConfirmPaymentCallbackListener { data, onPaymentResultCallback ->
+        confirmPaymentClickListener = ConfirmPaymentClickListener { data, onPaymentResultCallback ->
             callback(PaymentRequestData.parse(data), onPaymentResultCallback)
         }
     }
 
-    fun onPaymentConfirmButtonCallbackWithMap(
+    fun onPaymentConfirmButtonClickWithMap(
         callback: (
             data: Map<String, Any?>,
             onPaymentResultCallback: (Boolean) -> Unit
         ) -> Unit
     ) {
-        confirmPaymentListener = ConfirmPaymentCallbackListener { data, onPaymentResultCallback ->
+        confirmPaymentClickListener = ConfirmPaymentClickListener { data, onPaymentResultCallback ->
             callback(PaymentRequestData.toMap(data), onPaymentResultCallback)
         }
     }
 
-    fun onPaymentConfirmButtonCallback(listener: ConfirmPaymentCallbackListener) {
-        confirmPaymentListener = listener
+    fun onPaymentConfirmButtonClick(listener: ConfirmPaymentClickListener) {
+        confirmPaymentClickListener = listener
     }
 
     private fun dispatchConfirmTriggered(
         data: String,
         onPaymentResultCallback: (Boolean) -> Unit
     ) {
-        confirmPaymentListener?.onConfirmPaymentCallback(data, onPaymentResultCallback)
+        confirmPaymentClickListener?.onConfirmPaymentCallback(data, onPaymentResultCallback)
     }
 
     fun onEvent(listener: PaymentEventListener) {
@@ -384,7 +384,7 @@ class PaymentWidgetView : FrameLayout {
             frameLayout.post { this.getFragment()?.view?.requestLayout() }
         }
         this.fragment?.setOnPaymentResult(::dispatchResult)
-        this.fragment?.setOnPaymentConfirmButtonCallback(::dispatchConfirmTriggered)
+        this.fragment?.setOnPaymentConfirmButtonClick(::dispatchConfirmTriggered)
         onEventCallback?.let { this.fragment?.setOnEventCallback(it) }
         this.fragment?.setOnExit {
             removeWidget()

--- a/app/src/main/kotlin/io/hyperswitch/view/PaymentWidgetView.kt
+++ b/app/src/main/kotlin/io/hyperswitch/view/PaymentWidgetView.kt
@@ -47,7 +47,7 @@ fun interface PaymentResultListener {
 }
 
 fun interface ConfirmPaymentClickListener {
-    fun onConfirmPaymentCallback(data: String, onPaymentResultCallback: (Boolean) -> Unit)
+    fun onConfirmPaymentCallback(data: String, onConfirmPaymentCallback: (Boolean) -> Unit)
 }
 
 
@@ -218,22 +218,22 @@ class PaymentWidgetView : FrameLayout {
     fun onPaymentConfirmButtonClick(
         callback: (
             data: PaymentRequestData?,
-            onPaymentResultCallback: (Boolean) -> Unit
+            onConfirmPaymentCallback: (Boolean) -> Unit
         ) -> Unit
     ) {
-        confirmPaymentClickListener = ConfirmPaymentClickListener { data, onPaymentResultCallback ->
-            callback(PaymentRequestData.parse(data), onPaymentResultCallback)
+        confirmPaymentClickListener = ConfirmPaymentClickListener { data, onConfirmPaymentCallback ->
+            callback(PaymentRequestData.parse(data), onConfirmPaymentCallback)
         }
     }
 
     fun onPaymentConfirmButtonClickWithMap(
         callback: (
             data: Map<String, Any?>,
-            onPaymentResultCallback: (Boolean) -> Unit
+            onConfirmPaymentCallback: (Boolean) -> Unit
         ) -> Unit
     ) {
-        confirmPaymentClickListener = ConfirmPaymentClickListener { data, onPaymentResultCallback ->
-            callback(PaymentRequestData.toMap(data), onPaymentResultCallback)
+        confirmPaymentClickListener = ConfirmPaymentClickListener { data, onConfirmPaymentCallback ->
+            callback(PaymentRequestData.toMap(data), onConfirmPaymentCallback)
         }
     }
 
@@ -243,9 +243,9 @@ class PaymentWidgetView : FrameLayout {
 
     private fun dispatchConfirmTriggered(
         data: String,
-        onPaymentResultCallback: (Boolean) -> Unit
+        onConfirmPaymentCallback: (Boolean) -> Unit
     ) {
-        confirmPaymentClickListener?.onConfirmPaymentCallback(data, onPaymentResultCallback)
+        confirmPaymentClickListener?.onConfirmPaymentCallback(data, onConfirmPaymentCallback)
     }
 
     fun onEvent(listener: PaymentEventListener) {

--- a/app/src/main/kotlin/io/hyperswitch/view/PaymentWidgetView.kt
+++ b/app/src/main/kotlin/io/hyperswitch/view/PaymentWidgetView.kt
@@ -20,6 +20,7 @@ import io.hyperswitch.PaymentConfiguration
 import io.hyperswitch.PaymentEventListener
 import io.hyperswitch.model.ElementUpdateIntentResult
 import io.hyperswitch.paymentsession.LaunchOptions
+import io.hyperswitch.paymentsheet.PaymentRequestData
 import io.hyperswitch.paymentsheet.PaymentResult
 import io.hyperswitch.paymentsheet.PaymentSheet
 import io.hyperswitch.react.HyperFragment
@@ -45,11 +46,15 @@ fun interface PaymentResultListener {
     fun onPaymentResult(result: PaymentResult)
 }
 
+fun interface ConfirmPaymentCallbackListener {
+    fun onConfirmPaymentCallback(data: String, onPaymentResultCallback: (Boolean) -> Unit)
+}
+
+
 /**
  * Extension function to convert PaymentSheet.Configuration to Map<String, Any>.
  * TODO: Fill in the actual mapping implementation.
  */
-fun PaymentSheet.Configuration.toMap(): Map<String, Any> = emptyMap()
 
 class PaymentWidgetView : FrameLayout {
     private var widgetConfig: PaymentWidgetConfig? = null
@@ -61,6 +66,8 @@ class PaymentWidgetView : FrameLayout {
     private var sdkAuthorization: String = ""
 
     private var resultListener: PaymentResultListener? = null
+
+    private var confirmPaymentListener: ConfirmPaymentCallbackListener? = null
     private var subscribedEvents: List<String> = emptyList()
 
     private var onEventCallback: PaymentEventListener? = null
@@ -164,9 +171,11 @@ class PaymentWidgetView : FrameLayout {
             }
 
             is PaymentWidgetConfig.ReactNative -> {
-                val configMap = io.hyperswitch.utils.ConversionUtils.readableMapToMap(c.configuration as com.facebook.react.bridge.ReadableMap)
+                val configMap =
+                    io.hyperswitch.utils.ConversionUtils.readableMapToMap(c.configuration as com.facebook.react.bridge.ReadableMap)
                 this.launchOptions.toBundle(configMap)
             }
+
             null -> null
         }
     }
@@ -204,6 +213,39 @@ class PaymentWidgetView : FrameLayout {
     /** Dispatches the result to the registered listener */
     private fun dispatchResult(result: PaymentResult) {
         resultListener?.onPaymentResult(result)
+    }
+
+    fun onPaymentConfirmButtonCallback(
+        callback: (
+            data: PaymentRequestData?,
+            onPaymentResultCallback: (Boolean) -> Unit
+        ) -> Unit
+    ) {
+        confirmPaymentListener = ConfirmPaymentCallbackListener { data, onPaymentResultCallback ->
+            callback(PaymentRequestData.parse(data), onPaymentResultCallback)
+        }
+    }
+
+    fun onPaymentConfirmButtonCallbackWithMap(
+        callback: (
+            data: Map<String, Any?>,
+            onPaymentResultCallback: (Boolean) -> Unit
+        ) -> Unit
+    ) {
+        confirmPaymentListener = ConfirmPaymentCallbackListener { data, onPaymentResultCallback ->
+            callback(PaymentRequestData.toMap(data), onPaymentResultCallback)
+        }
+    }
+
+    fun onPaymentConfirmButtonCallback(listener: ConfirmPaymentCallbackListener) {
+        confirmPaymentListener = listener
+    }
+
+    private fun dispatchConfirmTriggered(
+        data: String,
+        onPaymentResultCallback: (Boolean) -> Unit
+    ) {
+        confirmPaymentListener?.onConfirmPaymentCallback(data, onPaymentResultCallback)
     }
 
     fun onEvent(listener: PaymentEventListener) {
@@ -254,11 +296,12 @@ class PaymentWidgetView : FrameLayout {
                 this.sdkAuthorization = it
             }
             this.fragment?.updatePaymentIntentComplete(sdkAuthorization, callback)
-                ?: callback(ElementUpdateIntentResult.Failure(
-                    Throwable("Fragment not attached").apply {
-                        initCause(Throwable("FRAGMENT_NOT_ATTACHED"))
-                    }
-                ))
+                ?: callback(
+                    ElementUpdateIntentResult.Failure(
+                        Throwable("Fragment not attached").apply {
+                            initCause(Throwable("FRAGMENT_NOT_ATTACHED"))
+                        }
+                    ))
         } else {
             callback(ElementUpdateIntentResult.Success)
         }
@@ -279,10 +322,12 @@ class PaymentWidgetView : FrameLayout {
             "paymentMethodsManagement",
             "headless",
             "expressCheckout" -> return true
+
             "cvcWidget" -> return false
             else -> return false
         }
     }
+
     fun confirmCvcPayment(
         sdkAuthorization: String,
         paymentToken: String,
@@ -338,7 +383,8 @@ class PaymentWidgetView : FrameLayout {
 
             frameLayout.post { this.getFragment()?.view?.requestLayout() }
         }
-        this.fragment?.setOnPaymentResult { result -> dispatchResult(result) }
+        this.fragment?.setOnPaymentResult(::dispatchResult)
+        this.fragment?.setOnPaymentConfirmButtonCallback(::dispatchConfirmTriggered)
         onEventCallback?.let { this.fragment?.setOnEventCallback(it) }
         this.fragment?.setOnExit {
             removeWidget()

--- a/app/src/main/kotlin/io/hyperswitch/view/PaymentWidgetView.kt
+++ b/app/src/main/kotlin/io/hyperswitch/view/PaymentWidgetView.kt
@@ -245,7 +245,11 @@ class PaymentWidgetView : FrameLayout {
         data: String,
         onConfirmPaymentCallback: (Boolean) -> Unit
     ) {
-        confirmPaymentClickListener?.onConfirmPaymentCallback(data, onConfirmPaymentCallback)
+        if(confirmPaymentClickListener == null){
+            onConfirmPaymentCallback(true)
+        }else {
+            confirmPaymentClickListener?.onConfirmPaymentCallback(data, onConfirmPaymentCallback)
+        }
     }
 
     fun onEvent(listener: PaymentEventListener) {

--- a/demo-app/src/main/kotlin/io/hyperswitch/demoapp/WidgetActivity.kt
+++ b/demo-app/src/main/kotlin/io/hyperswitch/demoapp/WidgetActivity.kt
@@ -126,6 +126,14 @@ class WidgetActivity : AppCompatActivity(), HyperInterface {
             elements = hyperswitchInstance?.elements(sessionConfig)
             paymentSessionHandler = elements?.getPaymentSession()?.getCustomerSavedPaymentMethods()
              paymentElementBound = elements?.bind(paymentElement, buildConfiguration())
+            paymentElementBound?.onPaymentResult(::handleResult)
+//            paymentElementBound?.onPaymentConfirmButton { data, onPaymentResultCallback ->
+//                if (data != null && data.paymentMethodType == "google_pay"){
+//                    onPaymentResultCallback(true)
+//                    return@onPaymentConfirmButton
+//                }
+//                throw Exception("Failed to work out payment method type")
+//            }
             cvcWidgetBound = elements?.bind(cvcWidget) {
                 on(CvcWidgetEvents.CvcStatus) {
                     println(it)

--- a/demo-app/src/main/kotlin/io/hyperswitch/demoapp/WidgetActivity.kt
+++ b/demo-app/src/main/kotlin/io/hyperswitch/demoapp/WidgetActivity.kt
@@ -125,15 +125,15 @@ class WidgetActivity : AppCompatActivity(), HyperInterface {
             // All bindings share one Elements session — initialise once, bind sequentially.
             elements = hyperswitchInstance?.elements(sessionConfig)
             paymentSessionHandler = elements?.getPaymentSession()?.getCustomerSavedPaymentMethods()
-             paymentElementBound = elements?.bind(paymentElement, buildConfiguration())
+            paymentElementBound = elements?.bind(paymentElement, buildConfiguration())
             paymentElementBound?.onPaymentResult(::handleResult)
-//            paymentElementBound?.onPaymentConfirmButton { data, onPaymentResultCallback ->
-//                if (data != null && data.paymentMethodType == "google_pay"){
-//                    onPaymentResultCallback(true)
-//                    return@onPaymentConfirmButton
-//                }
-//                throw Exception("Failed to work out payment method type")
-//            }
+            paymentElementBound?.onPaymentConfirmButtonClick { data, onConfirmPaymentCallback ->
+                if (data != null && data.paymentMethodType == "google_pay"){
+                    onConfirmPaymentCallback(true)
+                    return@onPaymentConfirmButtonClick
+                }
+                throw Exception("Failed to work out payment method type")
+            }
             cvcWidgetBound = elements?.bind(cvcWidget) {
                 on(CvcWidgetEvents.CvcStatus) {
                     println(it)

--- a/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentRequestData.kt
+++ b/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentRequestData.kt
@@ -1,0 +1,30 @@
+package io.hyperswitch.paymentsheet
+
+import org.json.JSONObject
+
+data class PaymentRequestData(
+    val paymentMethodType: String?
+) {
+    companion object {
+        fun parse(data: String): PaymentRequestData? {
+            try {
+                val jsonObject = JSONObject(data)
+                return PaymentRequestData(
+                    jsonObject.optString("paymentMethodType")
+                )
+            } catch (_: Exception) {
+                return null
+            }
+        }
+        fun toMap(data: String): Map<String, Any?> {
+            try {
+                val jsonObject = JSONObject(data)
+                return mapOf(
+                    "paymentMethodType" to jsonObject.optString("paymentMethodType")
+                )
+            } catch (_: Exception) {
+                return emptyMap()
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds support for a callback when the payment confirm button is triggered, allowing the app to handle payment confirmation logic (such as for wallets) before proceeding. It introduces a new callback mechanism throughout the native and React Native integration layers, and provides a new data structure (`PaymentRequestData`) to pass payment method information. Additionally, it cleans up exception handling and refactors some method naming for clarity.

**Payment Confirm Button Callback Integration:**

* Added a new `CONFIRM_BUTTON_TRIGGERED` callback type and corresponding `HyperCallback.ConfirmButtonTriggered` class in `HyperFragment`, with support for registering and invoking this callback (`setOnPaymentConfirmButtonCallback`, `notifyConfirmButtonTriggered`) [[1]](diffhunk://#diff-d05d00a519538ac4dbb694f21f064699160827dee6b0ef97f79f46d66805fbf1L45-R56) [[2]](diffhunk://#diff-d05d00a519538ac4dbb694f21f064699160827dee6b0ef97f79f46d66805fbf1R80-R85) [[3]](diffhunk://#diff-d05d00a519538ac4dbb694f21f064699160827dee6b0ef97f79f46d66805fbf1R239-R245).
* Exposed `onPaymentConfirmButtonCallback` method in `HyperModule` for React Native to trigger the confirm button callback from JS, and connected it to the native callback mechanism.
* Added support in `HyperswitchBoundElement`, `HyperswitchElement`, and `PaymentWidgetView` to register and handle the new confirm button callback, including parsing callback data into a new `PaymentRequestData` structure [[1]](diffhunk://#diff-49664b84fb61b8603c5879a092ca732030e4b42fbdaab01ab1224fa3200ce014R62-R69) [[2]](diffhunk://#diff-51cd9b729443364726fc48036fe8f8e60277bf8f7c31e372ad0a0373c3efac44R82-R86) [[3]](diffhunk://#diff-247d6689a35b47818751b657ec0f0e336c2c047f0fe8c8e3f04177126a22bdd0R218-R250) [[4]](diffhunk://#diff-247d6689a35b47818751b657ec0f0e336c2c047f0fe8c8e3f04177126a22bdd0L341-R387).
* Introduced `ConfirmPaymentCallbackListener` functional interface and related methods in `PaymentWidgetView` to support various callback signatures and data formats [[1]](diffhunk://#diff-247d6689a35b47818751b657ec0f0e336c2c047f0fe8c8e3f04177126a22bdd0R49-L52) [[2]](diffhunk://#diff-247d6689a35b47818751b657ec0f0e336c2c047f0fe8c8e3f04177126a22bdd0R69-R70) [[3]](diffhunk://#diff-247d6689a35b47818751b657ec0f0e336c2c047f0fe8c8e3f04177126a22bdd0R218-R250).

**New Data Structure:**

* Added `PaymentRequestData` data class to encapsulate payment method type and provide parsing utilities for callback payloads.

**Refactoring and Cleanup:**

* Replaced multiple usages of `findFragmentWithRootTag` with `findViewWithRootTag` in `HyperModule` for more accurate view lookup and improved code consistency [[1]](diffhunk://#diff-767428ffe03dab7f5ac9eb70a6f13c91beae5d1718bbac4bed3b4c86a308836fL138-R167) [[2]](diffhunk://#diff-767428ffe03dab7f5ac9eb70a6f13c91beae5d1718bbac4bed3b4c86a308836fL156-R179) [[3]](diffhunk://#diff-767428ffe03dab7f5ac9eb70a6f13c91beae5d1718bbac4bed3b4c86a308836fL188-R209) [[4]](diffhunk://#diff-767428ffe03dab7f5ac9eb70a6f13c91beae5d1718bbac4bed3b4c86a308836fL197-R218).
* Improved exception handling formatting throughout `HyperFragment` for better readability [[1]](diffhunk://#diff-d05d00a519538ac4dbb694f21f064699160827dee6b0ef97f79f46d66805fbf1L359-R379) [[2]](diffhunk://#diff-d05d00a519538ac4dbb694f21f064699160827dee6b0ef97f79f46d66805fbf1L369-R397).

**Demo Integration:**

* Updated the demo app to show how to use the new `onPaymentConfirmButton` callback with `paymentElementBound`.