### PR TITLE
feat: forward custom backend and logging endpoints to RN bridge

### DIFF
--- a/app/src/main/kotlin/io/hyperswitch/sdk/HyperswitchInstance.kt
+++ b/app/src/main/kotlin/io/hyperswitch/sdk/HyperswitchInstance.kt
@@ -22,7 +22,7 @@ class HyperswitchInstance internal constructor(
         } else {
             initDeferred.await()
         }
-        val ps = PaymentSession(activity, hsConfig?.publishableKey, sessionConfig = config)
+        val ps = PaymentSession(activity, hsConfig, config)
         ps.initPaymentSession(config.sdkAuthorization)
         return ps
     }
@@ -35,7 +35,7 @@ class HyperswitchInstance internal constructor(
             } else {
                 initDeferred.await()
             }
-            val ps = PaymentSession(activity, hsConfig?.publishableKey, sessionConfig = config)
+            val ps = PaymentSession(activity, hsConfig, config)
             ps.initPaymentSession(config.sdkAuthorization)
             withContext(Dispatchers.Main) { onResult(ps) }
         }

--- a/app/src/main/kotlin/io/hyperswitch/view/PaymentWidgetView.kt
+++ b/app/src/main/kotlin/io/hyperswitch/view/PaymentWidgetView.kt
@@ -261,13 +261,15 @@ class PaymentWidgetView : FrameLayout {
         this.subscribedEvents = events
     }
 
-    fun getLaunchOptions(): Bundle =
-        this.launchOptions.getBundle(
+    fun getLaunchOptions(): Bundle {
+        val paymentConfig = PaymentConfiguration.getInstance(mContext)
+        return this.launchOptions.getBundle(
             publishableKey = this.publishableKey,
             configuration = resolveConfiguration(),
-            customBackendUrl = PaymentConfiguration.customBackendUrl,
-            customLogUrl = PaymentConfiguration.customLogUrl,
-            customParams = PaymentConfiguration.customParams as Map<String, Any>?,
+            customBackendUrl = paymentConfig.customBackendUrl,
+            customLogUrl = paymentConfig.customLogUrl,
+            customParams = paymentConfig.customParams?.let { launchOptions.fromBundle(it) }
+                as Map<String, Any>?,
             type = widgetType,
             from = when (widgetConfig) {
                 is PaymentWidgetConfig.Native -> "nativeWidget"
@@ -277,6 +279,7 @@ class PaymentWidgetView : FrameLayout {
             sdkAuthorization = this.sdkAuthorization,
             subscribedEvents = this.subscribedEvents,
         )
+    }
 
     fun confirmPayment(callback: (PaymentResult) -> Unit) {
         this.fragment?.confirmPayment(callback)

--- a/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsession/LaunchOptions.kt
+++ b/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsession/LaunchOptions.kt
@@ -75,17 +75,29 @@ class LaunchOptions(
         configuration: PaymentSheet.Configuration? = null,
         subscribedEvents: List<String> = emptyList()
     ): Bundle = Bundle().apply {
+        val customBackendEndpoint = PaymentConfiguration.getInstance(context).customBackendUrl
+        val customLoggingEndpoint = PaymentConfiguration.getInstance(context).customLogUrl
         putBundle("props", Bundle().apply {
             putString("type", "payment")
             putBundle("hyperswitchConfig", Bundle().apply {
                 putString("publishableKey", PaymentConfiguration.getInstance(context).publishableKey)
                 putString("profileId", null)
+                if (!customBackendEndpoint.isNullOrEmpty() || !customLoggingEndpoint.isNullOrEmpty()) {
+                    putBundle("customEndpoints", Bundle().apply {
+                        putBundle("overrideEndpoints", Bundle().apply {
+                            customBackendEndpoint?.takeIf { it.isNotEmpty() }
+                                ?.let { putString("customBackendEndpoint", it) }
+                            customLoggingEndpoint?.takeIf { it.isNotEmpty() }
+                                ?.let { putString("customLoggingEndpoint", it) }
+                        })
+                    })
+                }
             })
             putBundle("paymentSessionConfig", Bundle().apply {
                 putString("sdkAuthorization", sdkAuthorization)
             })
-            putString("customBackendUrl", PaymentConfiguration.getInstance(context).customBackendUrl)
-            putString("customLogUrl", PaymentConfiguration.getInstance(context).customLogUrl)
+            putString("customBackendUrl", customBackendEndpoint)
+            putString("customLogUrl", customLoggingEndpoint)
             putString("theme", configuration?.appearance?.theme?.name)
             putBundle("customParams", PaymentConfiguration.getInstance(context).customParams)
             // Inject subscribedEvents into the configuration bundle
@@ -114,6 +126,16 @@ class LaunchOptions(
             putString("from", from)
             putBundle("hyperswitchConfig", Bundle().apply {
                 putString("publishableKey", publishableKey ?: "")
+                if (!customBackendUrl.isNullOrEmpty() || !customLogUrl.isNullOrEmpty()) {
+                    putBundle("customEndpoints", Bundle().apply {
+                        putBundle("overrideEndpoints", Bundle().apply {
+                            customBackendUrl?.takeIf { it.isNotEmpty() }
+                                ?.let { putString("customBackendEndpoint", it) }
+                            customLogUrl?.takeIf { it.isNotEmpty() }
+                                ?.let { putString("customLoggingEndpoint", it) }
+                        })
+                    })
+                }
             })
             putBundle("paymentSessionConfig", Bundle().apply {
                 putString("sdkAuthorization", sdkAuthorization ?: "")


### PR DESCRIPTION
## Summary
  - Fix `HyperswitchInstance.initPaymentSession` so `customConfig` reaches `PaymentSession`. It was passing `hsConfig?.publishableKey` only, hitting the `(activity, publishableKey, sessionConfig)` constructor that nulls out the backend/log URLs —
   so `overrideCustomBackendEndpoint` / `overrideCustomLoggingEndpoint` were silently dropped.
  - `LaunchOptions.getBundle` (both overloads) now emits `hyperswitchConfig.customEndpoints.overrideEndpoints.{customBackendEndpoint, customLoggingEndpoint}`, matching the shape `parseEndpointsConfig` consumes in client-core (added in
  juspay/hyperswitch-client-core#509). Top-level `customBackendUrl`/`customLogUrl` are kept for backward compatibility.
  - Demo app sets `overrideCustomLoggingEndpoint = "https://integ.hyperswitch.io/logs/sdk"` to exercise the path end-to-end.