### PR TITLE
add hideCardNicknameField to PaymentSheet.Configuration

### DIFF
--- a/demo-app/src/main/kotlin/io/hyperswitch/demoapp/DemoConfig.kt
+++ b/demo-app/src/main/kotlin/io/hyperswitch/demoapp/DemoConfig.kt
@@ -180,6 +180,7 @@ fun buildDemoConfiguration(netceteraApiKey: String? = null): PaymentSheet.Config
         .displaySavedPaymentMethodsCheckbox(true)
         .displaySavedPaymentMethods(true)
         .displayDefaultSavedPaymentIcon(true)
+        .hideCardNicknameField(false)
         .disableBranding(true)
         .stickyPayButton(true)
         .redirectionInfo(PaymentSheet.Visibility.Auto)

--- a/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentSheet.kt
+++ b/hyperswitch-sdk-android-api/src/main/kotlin/io/hyperswitch/paymentsheet/PaymentSheet.kt
@@ -215,6 +215,9 @@ class PaymentSheet internal constructor(
 
         /** Whether to split card number, expiry, and CVC into separate input fields. */
         val splitCardFields: Boolean? = null,
+
+        /** Whether to hide the card nickname input field regardless of the mandate/save-card state. */
+        val hideCardNicknameField: Boolean? = null,
     ) : Parcelable {
         val bundle: Bundle
             get() {
@@ -272,6 +275,7 @@ class PaymentSheet internal constructor(
                     }
                     putBundle("paymentMethodLayout", paymentMethodLayout?.bundle)
                     if (splitCardFields != null) putBoolean("splitCardFields", splitCardFields)
+                    if (hideCardNicknameField != null) putBoolean("hideCardNicknameField", hideCardNicknameField)
                 }
             }
 
@@ -312,6 +316,7 @@ class PaymentSheet internal constructor(
             private var paymentMethodsConfig: List<PaymentMethodConfig>? = null
             private var paymentMethodLayout: PaymentMethodLayout? = null
             private var splitCardFields: Boolean? = null
+            private var hideCardNicknameField: Boolean? = null
             fun merchantDisplayName(merchantDisplayName: String) =
                 apply { this.merchantDisplayName = merchantDisplayName }
 
@@ -420,6 +425,9 @@ class PaymentSheet internal constructor(
             fun splitCardFields(splitCardFields: Boolean) =
                 apply { this.splitCardFields = splitCardFields }
 
+            fun hideCardNicknameField(hideCardNicknameField: Boolean) =
+                apply { this.hideCardNicknameField = hideCardNicknameField }
+
             fun build() = Configuration(
                 merchantDisplayName,
                 customer,
@@ -453,6 +461,7 @@ class PaymentSheet internal constructor(
                 paymentMethodsConfig,
                 paymentMethodLayout,
                 splitCardFields,
+                hideCardNicknameField,
             )
         }
     }


### PR DESCRIPTION
**Description:**

## What
Exposes `hideCardNicknameField` on `PaymentSheet.Configuration`, matching the new
client-core prop.

## How
Five sites, following `splitCardFields` exactly:
- `Configuration` data-class param `val hideCardNicknameField: Boolean? = null`
- `bundle` getter — `putBoolean` guarded on non-null
- Builder private var, builder setter, and the positional arg in `build()`

Uses the nullable `Boolean? = null` builder default (as `splitCardFields`/`stickyPayButton`
do) rather than the non-null style used by `displaySavedPaymentMethodsCheckbox` — a non-null
default would make the Builder always emit the key and override the ReScript default.

Appended last so `@JvmOverloads` and existing positional callers stay source-compatible.
`@Parcelize` generates the parcelling.

## Usage
```kotlin
PaymentSheet.Configuration.Builder("Example, Inc.")
    .hideCardNicknameField(true)
    .build()
